### PR TITLE
[BUG-FIX] /root/.maltrail/ not found on first run

### DIFF
--- a/core/update.py
+++ b/core/update.py
@@ -62,6 +62,14 @@ def update_trails(server=None, force=False, offline=False):
     trails = {}
     duplicates = {}
 
+    try:
+        if not os.path.isdir(USERS_DIR):
+            os.makedirs(USERS_DIR, 0755)
+    except Exception, ex:
+        exit("[!] something went wrong during creation of directory '%s' ('%s')" % (USERS_DIR, ex))
+
+    _chown(USERS_DIR)
+
     if server:
         print "[i] retrieving trails from provided 'UPDATE_SERVER' server..."
         content = retrieve_content(server)
@@ -81,14 +89,6 @@ def update_trails(server=None, force=False, offline=False):
         for dirpath, dirnames, filenames in os.walk(os.path.abspath(os.path.join(ROOT_DIR, os.path.expanduser(config.CUSTOM_TRAILS_DIR)))) :
             for filename in filenames:
                 trail_files.add(os.path.abspath(os.path.join(dirpath, filename)))
-
-    try:
-        if not os.path.isdir(USERS_DIR):
-            os.makedirs(USERS_DIR, 0755)
-    except Exception, ex:
-        exit("[!] something went wrong during creation of directory '%s' ('%s')" % (USERS_DIR, ex))
-
-    _chown(USERS_DIR)
 
     if not trails and (force or not os.path.isfile(TRAILS_FILE) or (time.time() - os.stat(TRAILS_FILE).st_mtime) >= config.UPDATE_PERIOD or os.stat(TRAILS_FILE).st_size == 0 or any(os.stat(_).st_mtime > os.stat(TRAILS_FILE).st_mtime for _ in trail_files)):
         print "[i] updating trails (this might take a while)..."


### PR DESCRIPTION
When application started with UPDATE_SERVER setting activated at the first run, below code will get an exception.

Source code address core/update.py Line 71
```python
with _fopen(TRAILS_FILE, "w+b") as f:
        f.write(content)
trails = load_trails()
```

You will see an unwaiten exit
```shell
$ ~> python /etc/maltrail/sensor.py
Maltrail (sensor) #v0.10.182

[i] using configuration file '/etc/maltrail/maltrail.conf'
[i] using '/var/log/maltrail' for log storage
[?] at least 384MB of free memory required
[i] retrieving trails from provided 'UPDATE_SERVER' server...
$ ~>
```

Exception gotten from core/update.py Line 52
```python
def _fopen(filepath, mode="rb"):
    retval = open(filepath, mode)
    if "w+" in mode:
        _chown(filepath)
    return retval
```

When try/except block written, you will see output
```python
Traceback (most recent call last):
  File "/etc/maltrail/core/update.py", line 72, in update_trails
    with _fopen(TRAILS_FILE, "w+b") as f:
  File "/etc/maltrail/core/update.py", line 52, in _fopen
    retval = open(filepath, mode)
IOError: [Errno 2] No such file or directory: '/root/.maltrail/trails.csv'
```


----------------------------------------------------------------------------
### Platform details

OS: Ubuntu 16.04.1
Python Version: Python 2.7.12

maltrail.conf
```
# [Server]

# Listen address of (reporting) HTTP server
HTTP_ADDRESS X.X.X.X

# Listen port of (reporting) HTTP server
HTTP_PORT 8338

# Use SSL/TLS
USE_SSL false

# SSL/TLS (private/cert) PEM file (e.g. openssl req -new -x509 -keyout server.pem -out server.pem -days 1023 -nodes)
#SSL_PEM misc/server.pem

# User entries (username:sha256(password):UID:filter_netmask(s))
# Note(s): sha256(password) can be generated on Linux with: echo -n 'password' | sha256sum | cut -d " " -f 1
#          UID >= 1000 have only rights to display results
#          filter_netmask(s) is/are used to filter results
USERS
    admin:PASSWORD_POINTER:0:0.0.0.0/0                        # changeme!

# Listen address of (log collecting) UDP server
#UDP_ADDRESS X.X.X.X

# Listen port of (log collecting) UDP server
#UDP_PORT 8337

# Should server do the trail updates too (to support UPDATE_SERVER)
USE_SERVER_UPDATE_TRAILS false

# [Sensor]

# Number of processes
PROCESS_COUNT $CPU_CORES

# Disable setting of CPU affinity (with schedtool) on Linux machines (e.g. because of load issues with other processes)
DISABLE_CPU_AFFINITY false

# Use feeds (too) in trail updates
USE_FEED_UPDATES true

# Update trails after every given period (seconds)
UPDATE_PERIOD 86400

# Use remote custom feed (too) in trail updates
#CUSTOM_TRAILS_URL http://www.test.com/custom.txt

# Location of directory with custom trails (*.txt) files
CUSTOM_TRAILS_DIR ./trails/custom

# (Max.) size of multiprocessing network capture ring buffer (in bytes or percentage of total physical memory) used by sensor (e.g. 512MB)
CAPTURE_BUFFER 10%

# Interface used for monitoring (e.g. eth0, eth1)
MONITOR_INTERFACE any

# Network capture filter (e.g. ip)
# Note(s): more info about filters can be found at: https://danielmiessler.com/study/tcpdump/
#CAPTURE_FILTER ip or ip6
CAPTURE_FILTER udp or icmp or (tcp and (tcp[tcpflags] == tcp-syn or port 80 or port 1080 or port 3128 or port 8000 or port 8080 or port 8118))

# Sensor name to appear in produced logs
SENSOR_NAME $HOSTNAME

# Remote address to send log entries
LOG_SERVER X.X.X.X:8337

# Remote address to send syslog entries
#SYSLOG_SERVER X.X.X.X:514

# Use only (!) in cases when LOG_SERVER should be used for log storage
DISABLE_LOCAL_LOG_STORAGE false

# Remote address for pulling (latest) trail definitions (e.g. http://192.168.2.107:8338/trails)
UPDATE_SERVER http://X.X.X.X:8338/trails

# Use heuristic methods
USE_HEURISTICS true

# Capture HTTP requests with missing Host header (introducing potential false positives)
CHECK_MISSING_HOST false

# Check values in Host header (along with standard non-HTTP checks) for malicious DNS trails (introducing greater number of events)
CHECK_HOST_DOMAINS false

# Location of file with whitelisted entries (i.e. IP addresses, domain names, etc.) (note: take a look into 'misc/whitelist.txt')
#USER_WHITELIST

# [All]

# Show debug messages (in console output)
SHOW_DEBUG false

# Directory used for log storage
LOG_DIR $SYSTEM_LOG_DIR/maltrail

# HTTP(s) proxy address
#PROXY_ADDRESS http://192.168.5.101:8118
```

