### PR TITLE
Fixed typo in maltrail.conf

### DIFF
--- a/maltrail.conf
+++ b/maltrail.conf
@@ -89,8 +89,8 @@ CHECK_HOST_DOMAINS false
 # Location of file with whitelisted entries (i.e. IP addresses, domain names, etc.) (note: take a look into 'misc/whitelist.txt')
 #USER_WHITELIST
 
-# Location of file with ignore event rules. Example under misc/ignore_event.txt
-#USER_IGNORELIST misc/ignore_event.txt
+# Location of file with ignore event rules. Example under misc/ignore_events.txt
+#USER_IGNORELIST misc/ignore_events.txt
 
 # [All]
 


### PR DESCRIPTION
In line 91-92: `misc/ignore_event.txt` -> `misc/ignore_events.txt`