### PR TITLE
whitelist.txt: Cloudfare and IBM pub DNS addresses

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -650,6 +650,8 @@ forestapp.cc
 frog.wix.com
 8.8.4.4
 8.8.8.8
+1.1.1.1
+9.9.9.9
 opendsp.com
 tru.am
 put.re


### PR DESCRIPTION
added IPs of public DNS to Generic section:
1.1.1.1 (Cloudfare)
9.9.9.9 (IBM)