### PR TITLE
whitelist.txt: updated list for Kaspersky Lab

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -85,6 +85,10 @@ internationalmonetaryfund.org
 ipv6test.com
 ipv6test.net
 kaspersky.com
+kaspersky.de
+kaspersky.fr
+kaspersky.ru
+kaspersky.ua
 laola1.tv
 live.com
 lswcdn.net


### PR DESCRIPTION
Updated domains for Kaspersky Lab Anti-Virus software:
kaspersky.de
kaspersky.fr
kaspersky.ru
kaspersky.ua