### PR TITLE
Create elf_backdoor_agent_fz.txt

### DIFF
--- a/trails/static/malware/elf_backdoor_agent_fz.txt
+++ b/trails/static/malware/elf_backdoor_agent_fz.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://detux.org/report.php?sha256=57fd8c235010664ed133cfa92ef59aa0aab8b9adda25107f929d6fb87bcff363
+# Reference: https://www.virustotal.com/#/file/57fd8c235010664ed133cfa92ef59aa0aab8b9adda25107f929d6fb87bcff363/detection
+# Reference: https://virusscan.jotti.org/en-US/filescanjob/y45vbpyian
+
+118.193.182.103


### PR DESCRIPTION
Found on: https://detux.org/report.php?sha256=57fd8c235010664ed133cfa92ef59aa0aab8b9adda25107f929d6fb87bcff363

Multi-functional ELF-malware: downloader, dns-spoofing, http-attacker

Detection:
- Dr.Web Anti-Virus: Linux.BackDoor.Siggen.98
- Kaspersky Lab Anti-Virus: HEUR:Trojan.Linux.Agent.fz