### PR TITLE
Create elf_mirai.txt

### DIFF
--- a/trails/static/malware/elf_mirai.txt
+++ b/trails/static/malware/elf_mirai.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: http://blog.malwaremustdie.org/2016/08/mmd-0056-2016-linuxmirai-just.html
+# Reference: https://www.fortinet.com/blog/industry-trends/iot-based-linux-mirai-frequently-asked-questions.html
+
+89.186.189.241
+142.58.24.170
+143.239.27.171
+182.232.250.171


### PR DESCRIPTION
Added example of updatible file for Linux.Mirai IP-s static trails. This file should be as add-on to /maltrail/trails/feeds/ main public Linux.Mirai IP-s list (which is currently absent in Maltrail feeds-list), because some IP-s can be missed in main trail-list.

Address of public Linux.Mirai IP-s list: [0] http://sanyalnet-cloud-vps.freeddns.org/mirai-ips.txt , which should compulsory added to /maltrail/trails/feeds/

Also addresses from [0] can be replicated to static elf_mirai.txt trails to prevent case, if [0] is unaccessible for some reason, and not to loose detection of Linux.Mirai trails.

Current IP-s, mentioned in elf_mirai.txt are absent in [0]. But detux.org returns couple of Linux.Mirai samples on them. That's why I consider this file (elf_mirai.txt) as an add-on to main feed-trail from [0], which is also should be added to Maltrail feeds.

Thanks!