### PR TITLE
Create elf_zyarinig.txt

### DIFF
--- a/trails/static/malware/elf_zyarinig.txt
+++ b/trails/static/malware/elf_zyarinig.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: http://seclists.org/bugtraq/2016/Oct/26 (similar functionality, described in paragraph 13). IP list from detux.org
+
+173.163.187.218
+173.234.9.226
+188.213.165.209
+193.204.114.233
+212.45.144.206
+31.14.131.188
+62.210.6.26


### PR DESCRIPTION
Zyarinig ELF Backdoor. Related IP-s from detux.org

[1] https://www.virustotal.com/en/file/96a81eec1f9992c1681cc8ec83a60ba5bf8139e43f9cf20ef78a5f8c9b15c75f/analysis/
[2] https://www.virustotal.com/en/file/2d50db92171aa4305659ee7ae72199110a1bd0c0b063dea28a5dc33e0f9c6112/analysis/

Initially Zyarinig name was given by KasperskyLab: HEUR:Backdoor.Linux.Zyarinig.a