### PR TITLE
whitelist.txt: updated for Zillya anti-virus

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -155,6 +155,9 @@ yahoo.com
 yahoodns.net
 yimg.com
 yvimg.kz
+zillya.com
+zillya.ua
+zillyaoem.com
 
 # to ignore in direct .exe downloads
 
@@ -180,6 +183,7 @@ digitalrivercontent.net
 divx.com
 download.drp.su
 download.geo.drweb.com
+download.zillya.com
 easeus.com
 filehippo.com
 foxitsoftware.com


### PR DESCRIPTION
- Added domains for Zillya Anti-Virus software (Ukraine):

zillya.com
zillya.ua
zillyaoem.com

-  To ignore in direct .exe downloads

download.zillya.com