### PR TITLE
Update whitelist.txt

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -118,6 +118,7 @@ outlook.com
 pandasecurity.com
 postimg.cc
 proofpoint.com
+protext.su
 pubnub.com
 rackcdn.com
 rarbg.to


### PR DESCRIPTION
- Added protext.su . It is educational web-site for technical writers in ex-USSR.