### PR TITLE
Create darkhydrus.txt

### DIFF
--- a/trails/static/malware/darkhydrus.txt
+++ b/trails/static/malware/darkhydrus.txt
@@ -1,0 +1,24 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://researchcenter.paloaltonetworks.com/2018/07/unit42-new-threat-actor-group-darkhydrus-targets-middle-east-government/
+
+0ffice.com
+0ffiice.com
+0utl00k.net
+0utlook.bid
+allexa.net
+anyconnect.stream
+bigip.stream
+cisc0.net
+fortiweb.download
+hotmai1.com
+kaspersky.host
+kaspersky.science
+maccaffe.com
+microtik.stream
+micrrosoft.net
+msdncss.com
+owa365.bid
+symanteclive.download
+windowsdefender.win


### PR DESCRIPTION
[0] https://researchcenter.paloaltonetworks.com/2018/07/unit42-new-threat-actor-group-darkhydrus-targets-middle-east-government/

```
Campaign Analysis
```
```The following domains are configured within the payload to be used as C2s.```