### PR TITLE
Update whitelist.txt

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -45,6 +45,7 @@ cloudfront.net
 colocrossing.com
 coppersurfer.tk
 councilforeuropeanstudies.org
+cyfral.net.ua
 da3e3.net
 dataprotection.com.ua
 demdex.net


### PR DESCRIPTION
- Added cyfral.net.ua. It is web-site of Ukrainian company, which manufactures and sells alarm hardware, hardware security keys, etc.