### PR TITLE
Create apt_leafminer.txt

### DIFF
--- a/trails/static/malware/apt_leafminer.txt
+++ b/trails/static/malware/apt_leafminer.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://www.symantec.com/blogs/threat-intelligence/leafminer-espionage-middle-east
+
+adobe-flash.us
+adobe-plugin.bid
+ilhost.in
+iqhost.us
+microsoft-office-free-templates.in
+microsoft-office-free-templates-download.btc-int.in
+offiice365.us


### PR DESCRIPTION
[0] https://www.symantec.com/blogs/threat-intelligence/leafminer-espionage-middle-east

1) Some domains (e.g. adobe-plugin.bid) are detected by ```bambenekconsulting``` feed-trail as ```ramnit malware``` and simultaneously as suspicious by MT static trail. If Leafminer APT uses Ramnit domains, let us also detect Leafminer by static trail.

2) Also domains ```adobe-plugin.bid```, ```microsoft-office-free-templates.in```, ```microsoft-office-free-templates-download.btc-int.in``` are marked as Sinkholed by Kryptos Logic (https://www.kryptoslogic.com/). So trail sinkhole_kryptoslogic.txt will be also created.