### PR TITLE
whitelist for KVT manufacturer/vendor

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -101,6 +101,9 @@ kaspersky.de
 kaspersky.fr
 kaspersky.ru
 kaspersky.ua
+kvt.su
+kvt.tools
+kvt-shop.ru
 laola1.tv
 live.com
 lswcdn.net


### PR DESCRIPTION
- Added addresses of KVT Company. It is Russian manufacturer/vendor of electro-technical equipment.