### PR TITLE
whitelist for Shtok manufacturer/vendor

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -140,6 +140,8 @@ sophosxl.net
 sophoslive.net
 spiegel.de
 spotify.com
+shtok.ru
+shtok.su
 street-directory.com.au
 tawk.to
 testanalytics.net


### PR DESCRIPTION
- Added addresses of Shtok Company. It is also Russian manufacturer/vendor of electro-technical equipment.