### PR TITLE
Create firefox_banned_addons.txt

### DIFF
--- a/misc/firefox_banned_addons.txt
+++ b/misc/firefox_banned_addons.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1483995
+# Reference: https://www.bleepingcomputer.com/news/security/mozilla-removes-23-firefox-add-ons-that-snooped-on-users/
+
+136.243.163.73


### PR DESCRIPTION
Hello!

[0] https://bugzilla.mozilla.org/show_bug.cgi?id=1483995
[1] https://www.bleepingcomputer.com/news/security/mozilla-removes-23-firefox-add-ons-that-snooped-on-users/

From [1]: ``` Besides Web Security, other banned add-ons include Browser Security, Browser Privacy, and Browser Safety. All of these have been observed sending data to the same server as Web Security, located at 136.243.163.73. ```

I remember, IPs are not acceptable in most cases for MT, but here it seems to be an exclusion to have the respective static trail. 

Please, consider. Thanks!