### PR TITLE
Update blackshades.txt

### DIFF
--- a/trails/static/malware/blackshades.txt
+++ b/trails/static/malware/blackshades.txt
@@ -13679,3 +13679,15 @@ brandon02.no-ip.info
 callofdutyservers.no-ip.biz
 dns.no-ip.biz
 galyanie2.no-ip.info
+
+# Reference: https://blog.talosintelligence.com/2018/08/threat-roundup-0810-0817.html
+
+1facebookwanker.no-ip.biz
+2facebookwanker.no-ip.biz
+3facebookwanker.no-ip.biz
+4facebookwanker.no-ip.biz
+5facebookwanker.no-ip.biz
+6facebookwanker.no-ip.biz
+7facebookwanker.no-ip.biz
+8facebookwanker.no-ip.biz
+9facebookwanker.no-ip.biz


### PR DESCRIPTION
[0] https://blog.talosintelligence.com/2018/08/threat-roundup-0810-0817.html

See ```Win.Dropper.Ainslot-6646850-0``` section. Because ```facebookwanker.no-ip.biz``` is also detected as ```blackshades``` MT static trail, I put all addresses mentioned in Cisco article here.

It's also pity a little bit, that MT trails do not support wildcard characters. Something like: ```*facebookwanker.no-ip.biz``` or ```?facebookwanker.no-ip.biz``` to put one line instead of huge pile of similar lines.