### PR TITLE
Update bad_history.txt

### DIFF
--- a/trails/static/suspicious/bad_history.txt
+++ b/trails/static/suspicious/bad_history.txt
@@ -31221,3 +31221,7 @@ zy.cccpan.com
 zya.com
 zz.611u.com
 zz87lhfda88.com
+
+# Reference: https://twitter.com/ps66uk/status/1032177208335450112
+
+occe.com


### PR DESCRIPTION
Added address from [0] https://twitter.com/ps66uk/status/1032177208335450112 to ```bad history``` trail, because ```lokibot``` c2 has direct address: ```http://occe.com/image1/image/Panel/five/fre.php``` (returns 404 at this moment), but ```occe.com``` site is not malicious by itself.

Direct ```http://occe.com/image1/image/Panel/five/fre.php``` will be added as ```lokibot``` trail in malware folder.