### PR TITLE
Update apt_lazarus.txt

### DIFF
--- a/trails/static/malware/apt_lazarus.txt
+++ b/trails/static/malware/apt_lazarus.txt
@@ -1,10 +1,18 @@
 # Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
 # See the file 'LICENSE' for copying permission
 
-# https://cdn.securelist.com/files/2017/04/Lazarus_Under_The_Hood_PDF_final.pdf
+# Reference: https://cdn.securelist.com/files/2017/04/Lazarus_Under_The_Hood_PDF_final.pdf
 
 exbonus.mrbasic.com
 movis-es.ignorelist.com
 tradeboard.mefound.com
 update.toythieves.com
 sap.misapor.ch
+
+# Reference: https://securelist.com/operation-applejeus/87553/
+
+www.celasllc.com
+185.142.236.226
+185.142.239.173
+196.38.48.121
+80.82.64.91


### PR DESCRIPTION
[0] https://securelist.com/operation-applejeus/87553/

```Domains and IPs```. I left IPs due to this phrase: ```We have confirmed that the C2 server addresses (196.38.48[.]121, 185.142.236[.]226) used in this attack have been used by the older variant of Fallchill.``` And they are alive. I think we can do an exception here for these IPs, which currently are not detected by any of used in MT trails\feeds despite on being used by two types of malware: Lazarus and Fallchill.