### PR TITLE
Create quasarrat.txt

### DIFF
--- a/trails/static/malware/quasarrat.txt
+++ b/trails/static/malware/quasarrat.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/DynamicAnalysis/status/1034828121126723584
+# Reference: https://twitter.com/James_inthe_box/status/1034829960647593984
+# Reference: https://pastebin.com/MgAd0CzR
+
+http://23.249.161.109/
+syscore.duckdns.org
+watchdogdns.duckdns.org


### PR DESCRIPTION
While feed-trails like ```malwarepatrol.net``` and ```tallosintelligence.com``` give to this resource softy name ```potential malware site```, let us have precise static trail.