### PR TITLE
Create magentocore.txt

### DIFF
--- a/trails/static/malware/magentocore.txt
+++ b/trails/static/malware/magentocore.txt
@@ -4,3 +4,46 @@
 # Reference: https://gwillem.gitlab.io/2018/08/30/magentocore.net_skimmer_most_aggressive_to_date/
 
 magentocore.net
+
+# Reference: https://www.riskiq.com/blog/labs/magecart-keylogger-injection/
+
+abuse-js.link
+angular.club
+cdn-js.link
+docstart.su
+govfree.pw
+jquery-cdn.top
+js-abuse.link
+js-abuse.su
+js-cdn.link
+js-link.su
+js-magic.link
+js-mod.su
+js-save.link
+js-save.su
+js-start.su
+js-stat.su
+js-sucuri.link
+js-syst.su
+js-top.link
+js-top.su
+jscript-cdn.com
+lolfree.pw
+mage-cdn.link
+mage-js.link
+mage-js.su
+magento-cdn.top
+mageonline.net
+mipss.su
+mod-js.su
+mod-sj.link
+sj-mod.link
+sj-syst.link
+stat-sj.link
+statdd.su
+statsdot.eu
+stecker.su
+stek-js.link
+syst-sj.link
+top-sj.link
+truefree.pw

--- a/trails/static/malware/magentocore.txt
+++ b/trails/static/malware/magentocore.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://gwillem.gitlab.io/2018/08/30/magentocore.net_skimmer_most_aggressive_to_date/
+
+magentocore.net


### PR DESCRIPTION
Address from [0] https://gwillem.gitlab.io/2018/08/30/magentocore.net_skimmer_most_aggressive_to_date/ to detect, which can be a good indicator for hosting admins.

[0] mage.js https://www.virustotal.com/#/file/4fbc747639e5573dc11a2230e6b8d4826bab6f7f3e5c12619963f06182a17ef4/detection
[1] clean.js https://www.virustotal.com/#/file/9cc482e1d040835ec39a52de8cdb26f4384f2dfcb6a9a9aab25ff201ff47365e/detection
[2] clear.js https://www.virustotal.com/#/file/32f7cf20328f993c605cba09d2b8995cc9143c1ee8c742177f96cca7cab77714/detection