### PR TITLE
Update androm.txt

### DIFF
--- a/trails/static/malware/androm.txt
+++ b/trails/static/malware/androm.txt
@@ -28,4 +28,3 @@ ip138.com
 # Reference: https://blog.talosintelligence.com/2018/08/threat-roundup-0817-0824.html
 
 ajmanz.gq
-checkip.dyndns.org

--- a/trails/static/malware/androm.txt
+++ b/trails/static/malware/androm.txt
@@ -24,3 +24,8 @@ yzuhk.blogoveg.org
 ie.n502.com
 900cpa.cc
 ip138.com
+
+# Reference: https://blog.talosintelligence.com/2018/08/threat-roundup-0817-0824.html
+
+ajmanz.gq
+checkip.dyndns.org


### PR DESCRIPTION
[0] https://blog.talosintelligence.com/2018/08/threat-roundup-0817-0824.html ``` Win.Dropper.Delf-6652911-0 ```

Most AVs from VT return ```Androm``` name, starting from ```Kaspersky```.