### PR TITLE
Update nanocor.txt

### DIFF
--- a/trails/static/malware/nanocor.txt
+++ b/trails/static/malware/nanocor.txt
@@ -4,3 +4,8 @@
 # Reference: https://www.sophos.com/en-us/threat-center/threat-analyses/viruses-and-spyware/Troj~NanoCor-DM/detailed-analysis.aspx
 
 obiank.ddns.net
+
+# Reference: https://blog.talosintelligence.com/2018/08/threat-roundup-0817-0824.html
+
+blooping.ovh.net
+salako.net


### PR DESCRIPTION
[0] https://blog.talosintelligence.com/2018/08/threat-roundup-0817-0824.html ```Win.Dropper.Ponystealer-6652151-0``` section.

All mentioned in ```Win.Dropper.Ponystealer-6652151-0``` section samples call to ```blooping.ovh.net``` due to ```Relations``` tab from VT. E.g.: [1] https://www.virustotal.com/#/file/42bfe2c5da9a771a2aa3fd92e0ab8ad306d9469db287e223fb06a5b2f6411c9e/relations

```nanocor.txt``` trail because of ```Trojan. Nanocore.23``` (Dr.Web).