### PR TITLE
Create mikrotik-cve-2018-14847.txt

### DIFF
--- a/trails/static/malware/mikrotik-cve-2018-14847.txt
+++ b/trails/static/malware/mikrotik-cve-2018-14847.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://blog.netlab.360.com/7500-mikrotik-routers-are-forwarding-owners-traffic-to-the-attackers-how-is-yours-en/
+
+103.193.137.211
+185.69.155.23
+188.127.251.61
+206.255.37.1
+24.255.37.1
+37.1.207.114
+45.76.88.43
+5.9.183.69
+77.222.54.45
+95.154.216.167


### PR DESCRIPTION
[0] https://blog.netlab.360.com/7500-mikrotik-routers-are-forwarding-owners-traffic-to-the-attackers-how-is-yours-en/

Yes, IPs are not desirable, but this kind of malicious Mikrotik backflow traffic should be detected in some way.

Despite on ``` 2018-09-05 11:00 GMT+8, with the generous help from the AS64073, 103.193.137.211 has been promptly suspended and is no longer a threat.``` I left mentioned IP in list as a possible semaphore.