### PR TITLE
Update apt_darkhotel.txt

### DIFF
--- a/trails/static/malware/apt_darkhotel.txt
+++ b/trails/static/malware/apt_darkhotel.txt
@@ -300,3 +300,8 @@ win7smartupdate.com
 yahooservice.biz
 yellowleos.phpnet.us
 ypiz.net
+
+# Reference: https://ti.360.net/blog/articles/analyzing-attack-of-cve-2018-8373-and-darkhotel/
+# Reference: https://researchcenter.paloaltonetworks.com/2018/09/unit42-traps-prevents-wild-vbscript-zero-day-exploit-internet-explorer/
+
+windows-updater.net


### PR DESCRIPTION
Added address due to [0] https://ti.360.net/blog/articles/analyzing-attack-of-cve-2018-8373-and-darkhotel/ and [1] https://researchcenter.paloaltonetworks.com/2018/09/unit42-traps-prevents-wild-vbscript-zero-day-exploit-internet-explorer/ information.