### PR TITLE
Update ceidpagelock.txt

### DIFF
--- a/trails/static/malware/ceidpagelock.txt
+++ b/trails/static/malware/ceidpagelock.txt
@@ -3,6 +3,7 @@
 
 # Reference: https://research.checkpoint.com/ceidpagelock-a-chinese-rootkit/
 
+58fei.xyz
 tj999.top
 
 # Passive DNS for 42.51.223.86


### PR DESCRIPTION
Missed address from ```Figure 2: headers of homepage request from the C&C server.``` (initial https://research.checkpoint.com/ceidpagelock-a-chinese-rootkit/)