### PR TITLE
Update magentocore.txt

### DIFF
--- a/trails/static/malware/magentocore.txt
+++ b/trails/static/malware/magentocore.txt
@@ -52,3 +52,9 @@ truefree.pw
 
 http://89.47.162.248
 baways.com
+
+# Reference: https://www.riskiq.com/blog/labs/magecart-ticketmaster-breach/
+
+http://85.93.5.188
+http://94.156.133.211
+webfotce.me

--- a/trails/static/malware/magentocore.txt
+++ b/trails/static/malware/magentocore.txt
@@ -47,3 +47,8 @@ stek-js.link
 syst-sj.link
 top-sj.link
 truefree.pw
+
+# Reference: https://www.riskiq.com/blog/labs/magecart-british-airways-breach/
+
+http://89.47.162.248
+baways.com


### PR DESCRIPTION
Another ```magecart```: [0] https://www.riskiq.com/blog/labs/magecart-british-airways-breach/

```We saw proof of this on the domain name baways.com as well as the drop server path. The domain was hosted on 89.47.162.248 which is located in Romania and is, in fact, part of a VPS provider named Time4VPS based in Lithuania. ```