### PR TITLE
Create danabot.txt

### DIFF
--- a/trails/static/malware/danabot.txt
+++ b/trails/static/malware/danabot.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/MaelSecurity/status/1039752010713718785
+
+endbars.co
+readact.co


### PR DESCRIPTION
Addresses from [0] https://twitter.com/MaelSecurity/status/1039752010713718785

Can't find ```danabot``` trail, so, if it is synonym for an another malware-family, please, give a hint.