### PR TITLE
Create android_infostealer.txt

### DIFF
--- a/trails/static/malware/android_infostealer.txt
+++ b/trails/static/malware/android_infostealer.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://securelist.com/still-stealing/83343/
+
+extensionsapiversion.space
+guest-stat.com


### PR DESCRIPTION
[0] https://securelist.com/still-stealing/83343/

```android_infostealer.txt``` trail is the generic trail for Android apps (when they cannot be exactly classified), which try to steal user's info. It is similar to ```android_bankinfostealer.txt``` generic trail, but ```android_bankinfostealer.txt``` is for more specific cases.