### PR TITLE
Update azorult.txt

### DIFF
--- a/trails/static/malware/azorult.txt
+++ b/trails/static/malware/azorult.txt
@@ -165,3 +165,11 @@ grlo.tk
 qpzm.gq
 suka1.tk
 vfsv.tk
+
+# Reference: https://cert.gov.ua/news/44
+# Reference: https://www.virustotal.com/#/ip-address/192.198.87.130
+# Reference: https://www.virustotal.com/#/ip-address/185.193.38.78
+
+http://185.193.38.78/
+cashouts.tk
+vitani.tk


### PR DESCRIPTION
[0] https://cert.gov.ua/news/44 (UA). C2 IPs are given in the atricle. Have filtered them via VT Passive Domain Replication to cut compromised sites off.

```185.193.38.78``` from [0] is alive on moment of creation this PR.
```67.199.248.10``` and ```67.199.248.11``` from [0] lead to ```bit.ly``` link-shorter service. So, out of case.