### PR TITLE
Update elf_xbash.txt

### DIFF
--- a/trails/static/malware/elf_xbash.txt
+++ b/trails/static/malware/elf_xbash.txt
@@ -22,3 +22,6 @@ e3sas6tzvehwgpak.tk
 xmr.enjoytopic.tk
 daknobcq4zal6vbm.tk
 d3goboxon32grk2l.tk
+/Xbash
+/XbashX
+/XbashY


### PR DESCRIPTION
After the second look, let's add filename-semaphores ```/Xbash```, ```/XbashX``` and ```/XbashY``` as the trail. Not sure for ```/xapache``` and ```/zlibx``` (due to Google results). And ```/libhttpd``` is exactly bad idea to detect as a trail due to Google results. Please, update filename-semaphores list if ```/xapache```, ```/zlibx``` and ```/libhttpd``` are also acceptable to use here.