### PR TITLE
Create evilgrab.txt

### DIFF
--- a/trails/static/malware/evilgrab.txt
+++ b/trails/static/malware/evilgrab.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://citizenlab.ca/2015/10/targeted-attacks-ngo-burma/
+
+appeur.gnway.cc
+usacia.websecexp.com
+usafbi.websecexp.com
+webhttps.websecexp.com


### PR DESCRIPTION
[0] https://citizenlab.ca/2015/10/targeted-attacks-ngo-burma/

See ```Arbor Networks also identified common C2 domains used by this malware, and the Evilgrab malware reported by Palo Alto Networks:``` phrase.