### PR TITLE
Create surtr.txt

### DIFF
--- a/trails/static/malware/surtr.txt
+++ b/trails/static/malware/surtr.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://citizenlab.ca/2015/06/targeted-attacks-against-tibetan-and-hong-kong-groups-exploiting-cve-2014-4114/
+
+free1999.jkub.com


### PR DESCRIPTION
[0] https://citizenlab.ca/2015/06/targeted-attacks-against-tibetan-and-hong-kong-groups-exploiting-cve-2014-4114/

```The non-PlugX attack against Tibetan groups communicates with free1999.jkub.com, a C2 that we have previously observed in multiple campaigns using the Surtr malware family and targeting Tibetan groups.```