### PR TITLE
Create micropsia.txt

### DIFF
--- a/trails/static/malware/micropsia.txt
+++ b/trails/static/malware/micropsia.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://blog.radware.com/security/2018/07/micropsia-malware/
+
+max-mayfield.com
+young-spencer.com
+
+# Generic (callback) path
+
+/api/white_walkers/


### PR DESCRIPTION
[0] https://blog.radware.com/security/2018/07/micropsia-malware/

C2 addresses (```C2 Communication``` section). See also ```Upload Stolen Information``` section. Possibly, path-semaphore ```/api/white_walkers/``` can be changed, if ```/api/white_walkers/``` is not enough. I'm not aware, if MT parses something, when middle snippet of address is pointed. Anyway, ```/api/white_walkers/``` is the constant snippet and seems to be good for generic\heur detection.