### PR TITLE
Create android_buhsam.txt

### DIFF
--- a/trails/static/malware/android_buhsam.txt
+++ b/trails/static/malware/android_buhsam.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://file.gdatasoftware.com/web/de/documents/whitepaper/G_DATA_WhitePaper_-_Analysis_of_Android.Trojan-Spy.Buhsam.A.pdf
+
+/db/upload_whatsapp.php


### PR DESCRIPTION
[0] https://file.gdatasoftware.com/web/de/documents/whitepaper/G_DATA_WhitePaper_-_Analysis_of_Android.Trojan-Spy.Buhsam.A.pdf

P.S. BTW, if this malware is unknown and unnamed, this will be nice sign for ```malicious_php.txt``` trail. But... someone is rather scared of such functionality. ;) And, as I told that in ``````malicious_php.txt``` discussion, I put trails, which **can detect malware and were in use of malware**, and I strongly avoid of putting generic  trails like ```/index.php```, ```/login.php```, ```/redirect.php``` and so on.