### PR TITLE
Update malicious_php.txt

### DIFF
--- a/trails/static/suspicious/malicious_php.txt
+++ b/trails/static/suspicious/malicious_php.txt
@@ -31,6 +31,8 @@
 
 # Reference: https://twitter.com/James_inthe_box/status/1044957343568388097
 # Reference: https://pastebin.com/st49wnwB
+# Reference: https://pastebin.com/bPV4gVVL
 
+/4/forum.php
 /d2/forum.php
 /mlu/forum.php


### PR DESCRIPTION
Based on [0] https://pastebin.com/st49wnwB and [1] https://pastebin.com/bPV4gVVL ```chanitor.txt``` shows, that trail ```/4/forum.php``` is applicable as suspicious sign.

Usually clean forum-pages use ```/domain/forum```, ```/domain/forums``` ```forum.domain```, ```forums.domain``` schema.