### PR TITLE
Update konni.txt

### DIFF
--- a/trails/static/malware/konni.txt
+++ b/trails/static/malware/konni.txt
@@ -11,3 +11,7 @@
 /de/de_includes/mail/yandex.ru/donwload.php
 /weget/upload.php
 /weget/uploadtm.php
+
+# Reference: https://researchcenter.paloaltonetworks.com/2018/10/unit42-nokki-almost-ties-the-knot-with-dogcall-reaper-group-uses-new-malware-to-deploy-rat/
+
+kmbr1.nitesbr1.org


### PR DESCRIPTION
[0] https://researchcenter.paloaltonetworks.com/2018/10/unit42-nokki-almost-ties-the-knot-with-dogcall-reaper-group-uses-new-malware-to-deploy-rat/

```AutoFocus customers may track this threat via the KONNI, NOKKI, Final1stspy, DOGCALL, and Reaper```

So, goes to existed trail.