### PR TITLE
Update apt_pegasus.txt

### DIFF
--- a/trails/static/malware/apt_pegasus.txt
+++ b/trails/static/malware/apt_pegasus.txt
@@ -113,3 +113,22 @@ network190.com
 secure-access10.mx
 smscentro.com
 twiitter.com.mx
+
+# Reference: https://citizenlab.ca/2018/10/the-kingdom-came-to-canada-how-saudi-linked-digital-espionage-reached-canadian-soil/
+
+all-sales.info
+arabworld.biz
+beststores4u.com
+cheapapartmentsaroundme.com
+daily-sport.news
+dinneraroundyou.com
+findmyplants.com
+housesfurniture.com
+kingdom-news.com
+mideast-today.com
+muslim-world.info
+news-gazette.info
+nouvelles247.com
+promosdereve.com
+sunday-deals.com
+wonderfulinsights.com


### PR DESCRIPTION
[0] https://citizenlab.ca/2018/10/the-kingdom-came-to-canada-how-saudi-linked-digital-espionage-reached-canadian-soil/

Minus domains, which were already met before up in the list:

```akhbar-arabia.com```
```arabnews365.com```
```kingdom-deals.com```
```social-life.info```