### PR TITLE
Update quasarrat.txt

### DIFF
--- a/trails/static/malware/quasarrat.txt
+++ b/trails/static/malware/quasarrat.txt
@@ -5,7 +5,6 @@
 # Reference: https://twitter.com/James_inthe_box/status/1034829960647593984
 # Reference: https://pastebin.com/MgAd0CzR
 
-http://23.249.161.109/
 syscore.duckdns.org
 watchdogdns.duckdns.org
 


### PR DESCRIPTION
Replaced by https://github.com/stamparm/maltrail/pull/642/commits/5ebab3e10604c68d80871bb3fdbca6f2d8adc169 as ```generic malware```, because samples can be different.