### PR TITLE
Update crypto_mining.txt

### DIFF
--- a/trails/static/suspicious/crypto_mining.txt
+++ b/trails/static/suspicious/crypto_mining.txt
@@ -90,3 +90,7 @@ pool.cortins.tk
 pool.supportxmr.com
 xmr.crypto-pool.fr
 xmrpool.eu
+
+# Reference: https://researchcenter.paloaltonetworks.com/2018/10/unit42-fake-flash-updaters-push-cryptocurrency-miners/
+
+osdsoft.com


### PR DESCRIPTION
[0] https://researchcenter.paloaltonetworks.com/2018/10/unit42-fake-flash-updaters-push-cryptocurrency-miners/

```Near the beginning of the traffic, my infected Windows host generated an HTTP POST request to ```osdsoft[.]com.``` This domain is associated with updaters or installers pushing cryptocurrency miners and other unwanted software.```