### PR TITLE
Create ngioweb.txt

### DIFF
--- a/trails/static/malware/ngioweb.txt
+++ b/trails/static/malware/ngioweb.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/_CPResearch_/status/1050758973748666368
+
+interagitese.info
+blocklistdb.su
+yacdnmapper.su
+/vnnf4pffztd356ey
+
+# Reference: https://research.checkpoint.com/ramnits-network-proxy-servers/
+
+ngioweb.su


### PR DESCRIPTION
[0] https://twitter.com/_CPResearch_/status/1050758973748666368
[1] https://research.checkpoint.com/ramnits-network-proxy-servers/

From [1]: ```Ramnit is used as a loader for another malware named Ngioweb.``` So, let us have dedicated trail for this one.

Generic trail ```/vnnf4pffztd356ey``` is met both in [0] and [1].