### PR TITLE
Update netwire.txt

### DIFF
--- a/trails/static/malware/netwire.txt
+++ b/trails/static/malware/netwire.txt
@@ -8,3 +8,7 @@ mommyreal.ddns.net
 # Reference: https://www.sophos.com/en-us/threat-center/threat-analyses/viruses-and-spyware/Troj~NetWire-CC/detailed-analysis.aspx
 
 wwfvpsv9.serveftp.com
+
+# Reference: https://www.cyren.com/blog/articles/bad-things-come-in-pairs-3004
+
+dinesaad.hopto.org


### PR DESCRIPTION
[0] https://www.cyren.com/blog/articles/bad-things-come-in-pairs-3004

```Unfortunately, the download URL was inaccessible at the time of our analysis, so we were not able to obtain the intended executable payload. However, we were able to download another payload using the same filename (jon001.exe) from a different directory at the same site (hxxp://asurahomepg.ru/one/jon001.exe). Cyren detects the “jon001.exe” file as a backdoor trojan named W32/NetWiredRC.CW```