### PR TITLE
Update elf_mirai.txt

### DIFF
--- a/trails/static/malware/elf_mirai.txt
+++ b/trails/static/malware/elf_mirai.txt
@@ -215,6 +215,20 @@ ukrainianhorseriding.com
 # Generic trail from MT heuristic detection
 
 /juno
+/sefa.arm
+/sefa.arm5
+/sefa.arm6
+/sefa.arm7
+/sefa.i586
+/sefa.i686
+/sefa.m68k
+/sefa.mips
+/sefa.mpsl
+/sefa.ppc
+/sefa.ppc440
+/sefa.sh4
+/sefa.spc
+/sefa.x86
 
 # Reference: https://twitter.com/bad_packets/status/1051616610035806209
 


### PR DESCRIPTION
Found on heur MT detection of ```209.141.40.213/dlink``` (sh-loader). Folder ```209.141.40.213/bins/``` returns 403, but there was no problem on successful probing ELF-s by standard row of extensions (.mpsl, . arm , etc).