### PR TITLE
Create apt_gallmaker.txt

### DIFF
--- a/trails/static/malware/apt_gallmaker.txt
+++ b/trails/static/malware/apt_gallmaker.txt
@@ -1,0 +1,10 @@
+
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://www.symantec.com/blogs/threat-intelligence/gallmaker-attack-group
+# Reference: https://securityaffairs.co/wordpress/77041/apt/gallmaker-apt-emerges.html
+
+111.90.149.99/o2
+94.140.116.124/o2
+94.140.116.231/o2


### PR DESCRIPTION
[0] https://www.symantec.com/blogs/threat-intelligence/gallmaker-attack-group
[1] https://securityaffairs.co/wordpress/77041/apt/gallmaker-apt-emerges.html

Unfortunately, trails are poor. Even generic trail would be ```tooo..ooo generic```.