### PR TITLE
Update maltrail.conf

### DIFF
--- a/maltrail.conf
+++ b/maltrail.conf
@@ -107,4 +107,4 @@ LOG_DIR $SYSTEM_LOG_DIR/maltrail
 #PROXY_ADDRESS http://192.168.5.101:8118
 
 # Disable checking of sudo/Administrator privileges
-#DISABLE_CHECK_SUDO true
+#DISABLE_CHECK_SUDO false


### PR DESCRIPTION
```#DISABLE_CHECK_SUDO true``` is ubuntism, IMO. User/admin should really understand what does he do, when disabling ```sudo``` check. Should be ```false``` by default. It is familiar on manual putting ```yes``` in console on ssh-connections.