### PR TITLE
Create android_generic.txt

### DIFF
--- a/trails/static/malware/android_generic.txt
+++ b/trails/static/malware/android_generic.txt
@@ -3,4 +3,4 @@
 
 # Reference: https://now.avg.com/pc-malware-that-silently-installs-apps-on-your-android-device
 
-222.186.60.89
+222.186.60.89:1001

--- a/trails/static/malware/android_generic.txt
+++ b/trails/static/malware/android_generic.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://now.avg.com/pc-malware-that-silently-installs-apps-on-your-android-device
+
+222.186.60.89


### PR DESCRIPTION
[0] https://now.avg.com/pc-malware-that-silently-installs-apps-on-your-android-device

Unclassified Android malware. So, ```android_generic.txt``` as it was done for ```elf_generic.txt``` and ```generic.txt```. IP is alive and returns files. ({ "platform":"android", "service":"winusb", "args":"", "dl":"_hxxp://222.186.60.89:1001/driver/Android/Google/Google64.zip", "md5":"", "size":"" })