### PR TITLE
Correct the PCAP_FILE parameter

### DIFF
--- a/maltrail.conf
+++ b/maltrail.conf
@@ -57,6 +57,13 @@ CUSTOM_TRAILS_DIR ./trails/custom
 # (Max.) size of multiprocessing network capture ring buffer (in bytes or percentage of total physical memory) used by sensor (e.g. 512MB)
 CAPTURE_BUFFER 10%
 
+#
+# PCAP file to monitor instead of an actual network interface.
+# Using /dev/stdin allows the sensor to receive live packet captures from other programs like tzsp2pcap
+# https://github.com/thefloweringash/tzsp2pcap
+
+# PCAP_FILE /dev/stdin
+
 # Interface used for monitoring (e.g. eth0, eth1)
 MONITOR_INTERFACE any
 

--- a/sensor.py
+++ b/sensor.py
@@ -781,8 +781,8 @@ def init():
                 if not found:
                     exit("[!] missing function 'plugin(event_tuple, packet)' in plugin script '%s'" % filename)
 
-    if config.pcap_file:
-        _caps.append(pcapy.open_offline(config.pcap_file))
+    if config.PCAP_FILE:
+        _caps.append(pcapy.open_offline(config.PCAP_FILE))
     else:
         interfaces = set(_.strip() for _ in config.MONITOR_INTERFACE.split(','))
 


### PR DESCRIPTION
It is very useful to allow sensor.py to open a pcap file. Not only for offline analysis, but also allowing the sensor to receive pcap data streamed from another location. In that case /dev/stdin works. 

An example application is packet capture from Mikrotik routers. The builtin packet sniffer includes a streaming option that sends the captured packets over UDP using the TZSP protocol.

[https://en.wikipedia.org/wiki/TZSP](url)

### Example setup:

Just install tzsp2pcap [https://github.com/thefloweringash/tzsp2pcap](url)

on maltrail.conf set PCAP_FILE to /dev/stdin

and run `tzsp2pcap -f | python ./sensor.py`


### Example on the Mikrotik router, rather self explanatory.

`[admin@router] /tool sniffer> export 
/tool sniffer
set filter-interface=ether10.24 filter-operator-between-entries=and \
    streaming-enabled=yes streaming-server=192.168.1.202
[admin@router] /tool sniffer> 
`
