### PR TITLE
Create android_clickfraud.txt

### DIFF
--- a/trails/static/malware/android_clickfraud.txt
+++ b/trails/static/malware/android_clickfraud.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2014-2018 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://news.sophos.com/en-us/2018/12/06/android-clickfraud-fake-iphone/
+
+mobbt.com
+act.mobbt.com
+ads.mobbt.com
+sdk.mobbt.com
+exevents.nativeone.co


### PR DESCRIPTION
Domains from [0] https://news.sophos.com/en-us/2018/12/06/android-clickfraud-fake-iphone/