### PR TITLE
Create servhelper.txt

### DIFF
--- a/trails/static/malware/servhelper.txt
+++ b/trails/static/malware/servhelper.txt
@@ -1,0 +1,18 @@
+# Copyright (c) 2014-2019 Miroslav Stampar (@stamparm)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://www.proofpoint.com/us/threat-insight/post/servhelper-and-flawedgrace-new-malware-introduced-ta505
+
+afgdhjkrm.pw
+arepos.bit
+checksolutions.pw
+dedoshop.pw
+dedsolutions.bit
+pointsoft.pw
+
+# Generic trails
+
+/aggdst/Hasrt.php
+/ghuae/huadh.php
+/rest/serv.php
+/sav/s.php


### PR DESCRIPTION
[0] https://www.proofpoint.com/us/threat-insight/post/servhelper-and-flawedgrace-new-malware-introduced-ta505

C&C domains + generic trails. (/support/form.php is out of list by reason of being toooooooooo generic).