### PR TITLE
Delete elf_adb.txt

### DIFF
--- a/trails/static/malware/elf_adb.txt
+++ b/trails/static/malware/elf_adb.txt
@@ -1,6 +1,0 @@
-# Copyright (c) 2014-2019 Miroslav Stampar (@stamparm)
-# See the file 'LICENSE' for copying permission
-
-# Reference: https://telekomsecurity.github.io/2018/07/adb-botnet.html
-
-rippr.cc


### PR DESCRIPTION
IOCs are moved to ```elf_mirai```: https://github.com/stamparm/maltrail/pull/827/commits/a7c6f0b203f92f00b3e4acc0f3939c801582ccd9