### PR TITLE
Update malicious_php.txt

### DIFF
--- a/trails/static/suspicious/malicious_php.txt
+++ b/trails/static/suspicious/malicious_php.txt
@@ -72,3 +72,7 @@
 # Reference: https://twitter.com/nullcookies/status/1054496925469343744
 
 /anzhuo.php
+
+# Reference: https://twitter.com/ViriBack/status/1094261293693972480
+
+ibrandworld.com/jsl.php


### PR DESCRIPTION
Returns z-archive with two malicious LNK-loaders. ```ibrandworld.com``` is clean site by itself (possibly, compromised).