### PR TITLE
Update crypto_mining.txt

### DIFF
--- a/trails/static/suspicious/crypto_mining.txt
+++ b/trails/static/suspicious/crypto_mining.txt
@@ -90,3 +90,7 @@ pool.cortins.tk
 pool.supportxmr.com
 xmr.crypto-pool.fr
 xmrpool.eu
+
+# Reference: https://unit42.paloaltonetworks.com/mac-malware-steals-cryptocurrency-exchanges-cookies/
+
+koto-pool.work


### PR DESCRIPTION
Address, which is in use of installed miner. See ```Figure 6``` from https://unit42.paloaltonetworks.com/mac-malware-steals-cryptocurrency-exchanges-cookies/