### PR TITLE
Create osx_darthminer.txt

### DIFF
--- a/trails/static/malware/osx_darthminer.txt
+++ b/trails/static/malware/osx_darthminer.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference:https://unit42.paloaltonetworks.com/mac-malware-steals-cryptocurrency-exchanges-cookies/
+
+ptpb.pw


### PR DESCRIPTION
C2 address from https://unit42.paloaltonetworks.com/mac-malware-steals-cryptocurrency-exchanges-cookies/