### PR TITLE
Create sdbot.txt

### DIFF
--- a/trails/static/malware/sdbot.txt
+++ b/trails/static/malware/sdbot.txt
@@ -1,0 +1,41 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://www.virustotal.com/#/domain/*.afraid.org
+
+1liil11liil1.afraid.org
+1llsklll.afraid.org
+b0ts.afraid.org
+bent.afraid.org
+blardy.afraid.org
+demrt.afraid.org
+eleven.afraid.org
+exaturbo.afraid.org
+fjpjllj1lx.afraid.org
+four.afraid.org
+franck78.afraid.org
+fuckthebac0n.afraid.org
+imiill11lnot.afraid.org
+hlph0pfIipf10p.afraid.org
+jkfdlklj2adf2.afraid.org
+keki.afraid.org
+knix.afraid.org
+kqjckleaayzt.afraid.org
+l.1ove.you.oil1y.afraid.org
+ltfmwujrxcq.afraid.org
+mlqpayvtnau.afraid.org
+mpfd.afraid.org
+msup.afraid.org
+nanak.afraid.org
+nightwish.afraid.org
+nmgpoqqiwmh.afraid.org
+pwned.afraid.org
+serveme.afraid.org
+sjljjjjj.jjjjjjj.jjlj.afraid.org
+someothergoodhost.afraid.org
+till1liil1.afraid.org
+wyqggvow.afraid.org
+xanga.afraid.org
+xdcc.afraid.org
+xjtolamiy.afraid.org
+yang.afraid.org


### PR DESCRIPTION
Resounded from #919 , attempt number 3.  ```sdbot``` name is met most of the times for these domains due to VT files detection. Each trail contains its ```Communicating Files``` or ```Files Referring``` section on VT respectively.