### PR TITLE
Create monerominer.txt

### DIFF
--- a/trails/static/malware/monerominer.txt
+++ b/trails/static/malware/monerominer.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://blog.checkpoint.com/2019/03/19/check-point-forensic-files-monero-cryptominer-campaign-cryptojacking-crypto-apt-hacking/
+# Reference: https://otx.alienvault.com/pulse/5c9121ab482d361391fd3771
+
+d.beahh.com
+p.beahh.com
+v.beahh.com
+dl.haqo.net
+i.haqo.net
+sv.symcd.com


### PR DESCRIPTION
Moving to ```apt_unclassified.txt``` or renaming to ```apt_monerominer.txt``` is discussable.