### PR TITLE
Create filesharing_service.txt

### DIFF
--- a/trails/static/suspicious/filesharing_service.txt
+++ b/trails/static/suspicious/filesharing_service.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://securelist.com/piratebay-malware/89740/
+# Reference: https://www.virustotal.com/gui/domain/1fichier.com/relations
+
+1fichier.com


### PR DESCRIPTION
Filesharing services can be considered 50% as clean and 50% as malicious. So, I propose as ```suspicious``` trail. Also current ```1fichier``` was mentioned as source of malware.