### PR TITLE
Create winrar_cve-2018-20250.txt

### DIFF
--- a/trails/static/malware/winrar_cve-2018-20250.txt
+++ b/trails/static/malware/winrar_cve-2018-20250.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/PhysicalDrive0/status/1109871662890127360
+
+lofi.stream


### PR DESCRIPTION
I propose explicit-named trail instead of ```generic.txt``` one, because it would be useful and interesting for forensics goals, if someone in your LAN tries to use such services of malware/exploit compilation/creation.