### PR TITLE
Create apt_iec.txt

### DIFF
--- a/trails/static/malware/apt_iec.txt
+++ b/trails/static/malware/apt_iec.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/ClearskySec/status/1055404788635103232
+# Reference: https://www.clearskysec.com/iec/
+
+host-gv.appspot.com
+journey-in-israel.com
+iecr.co
+iec-co-il.com
+israelalerts.us
+israelalert.us
+pokemonisrael.yolasite.com
+sourcefarge.net
+users-management.com
+ynetnewes.com


### PR DESCRIPTION
```iec``` is the generic neutral name -- personally, I do not want to move this to ```unclassified```.