### PR TITLE
Create rat_unclassified.txt

### DIFF
--- a/trails/static/malware/rat_unclassified.txt
+++ b/trails/static/malware/rat_unclassified.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/blackorbird/status/1111610547961630721
+
+nikuman.eu


### PR DESCRIPTION
```rat_unclassified.txt``` logic is similar to ```apt_unclassified.txt``` : when you exactly know, the sample belongs to RAT, but have no idea on its name.