### PR TITLE
Update android_exodus.txt

### DIFF
--- a/trails/static/malware/android_exodus.txt
+++ b/trails/static/malware/android_exodus.txt
@@ -7,3 +7,27 @@
 ad1.fbsba.com
 attiva.exodus.esurv.it
 ws.my-local-weather.com
+
+# Reference: https://securitywithoutborders.org/blog/2019/03/29/exodus.html
+
+server1cs.exodus.connexxa.it
+server1bo.exodus.connexxa.it
+server1bs.exodus.connexxa.it
+server1cs.exodus.connexxa.it
+server1ct.exodus.connexxa.it
+server1fermo.exodus.connexxa.it
+server1fi.exodus.connexxa.it
+server1gioiat.exodus.connexxa.it
+server1na.exodus.connexxa.it
+server1rc.exodus.connexxa.it
+server2ct.exodus.connexxa.it
+server2cz.exodus.connexxa.it
+server2fi.exodus.connexxa.it
+server2mi.exodus.connexxa.it
+server2rc.exodus.connexxa.it
+server3bo.exodus.connexxa.it
+server3ct.exodus.connexxa.it
+server3.exodus.connexxa.it
+server3fi.exodus.connexxa.it
+server4fi.exodus.connexxa.it
+serverrt.exodus.connexxa.it


### PR DESCRIPTION
See this snippet for domains:

```To further corroborate the connection of the Exodus spyware with eSurv, the domain attiva.exodus.esurv.it resolves to the IP 212.47.242.236 which, according to public passive DNS data, in 2017 was used to host the domain server1cs.exodus.connexxa.it. Connexxa was a company also from Catanzaro. According to publicly available information, the founder of Connexxa seems to also be the CEO of eSurv.

Interestingly, we found other DNS records mostly from 2017 that follow a similar pattern and appear to contain two-letters codes for districts in Italy```