### PR TITLE
Update domain.txt

### DIFF
--- a/trails/static/suspicious/domain.txt
+++ b/trails/static/suspicious/domain.txt
@@ -4940,3 +4940,7 @@ zik.dj
 # Reference: https://twitter.com/ps66uk/status/1037866649435729921
 
 .fun
+
+# Reference: https://twitter.com/58_158_177_102/status/1087514326607355904
+
+.accountant


### PR DESCRIPTION
We have ```freetoper.accountant``` in ```ursnif.txt``` trail and current PR is based on this case of malware spreading via ```.accountant``` domain. Potentially this trail can give multiple FP-s, especially if such domain is not popular among mal-writers. Let us take some experiments for some days.