### PR TITLE
Create rogue_dns.txt

### DIFF
--- a/trails/static/suspicious/rogue_dns.txt
+++ b/trails/static/suspicious/rogue_dns.txt
@@ -14,3 +14,7 @@
 # Reference: https://twitter.com/bad_packets/status/1079251375987425280
 
 66.70.173.48
+
+# Reference: https://twitter.com/parseword/status/1093234498228097024
+
+144.217.191.145

--- a/trails/static/suspicious/rogue_dns.txt
+++ b/trails/static/suspicious/rogue_dns.txt
@@ -3,18 +3,18 @@
 
 # Reference: https://securelist.com/roaming-mantis-part-iv/90332/
 
-171.244.33.114
-171.244.33.116
+171.244.33.114:53
+171.244.33.116:53
 
 # Reference: https://twitter.com/bad_packets/status/1112087547050520577
 
-195.128.124.131
-195.128.126.165
+195.128.124.131:53
+195.128.126.165:53
 
 # Reference: https://twitter.com/bad_packets/status/1079251375987425280
 
-66.70.173.48
+66.70.173.48:53
 
 # Reference: https://twitter.com/parseword/status/1093234498228097024
 
-144.217.191.145
+144.217.191.145:53

--- a/trails/static/suspicious/rogue_dns.txt
+++ b/trails/static/suspicious/rogue_dns.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://securelist.com/roaming-mantis-part-iv/90332/
+
+171.244.33.114
+171.244.33.116
+
+# Reference: https://twitter.com/bad_packets/status/1112087547050520577
+
+195.128.124.131
+195.128.126.165

--- a/trails/static/suspicious/rogue_dns.txt
+++ b/trails/static/suspicious/rogue_dns.txt
@@ -10,3 +10,7 @@
 
 195.128.124.131
 195.128.126.165
+
+# Reference: https://twitter.com/bad_packets/status/1079251375987425280
+
+66.70.173.48


### PR DESCRIPTION
Attempt to detect scans\attacks\redirections with\to DNS servers, which are called ```Rogue```, as a ```suspicious``` separate trail. Hope, this is lifeful idea. Feel free to re-classificate.