### PR TITLE
Update apt_barium.txt

### DIFF
--- a/trails/static/malware/apt_barium.txt
+++ b/trails/static/malware/apt_barium.txt
@@ -1,6 +1,8 @@
 # Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
 # See the file 'LICENSE' for copying permission
 
+# Aliases: shadowhammer
+
 # Reference: https://securelist.com/operation-shadowhammer/89992/
 
 asushotfix.com


### PR DESCRIPTION
Adding info in ```Aliases:``` field, because ```shadowhammer``` name is quite more more popular, than ```barium```.