### PR TITLE
Fixed 120 issues of type: PYTHON_E402 throughout 3 files in repo.

### DIFF
--- a/core/update.py
+++ b/core/update.py
@@ -1,24 +1,5 @@
 #!/usr/bin/env python2
 
-"""
-Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
-See the file 'LICENSE' for copying permission
-"""
-
-import csv
-import glob
-import inspect
-import os
-import re
-import sqlite3
-import subprocess
-import sys
-import time
-import urllib2
-
-sys.dont_write_bytecode = True
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))  # to enable calling from current directory too
-
 from core.addr import addr_to_int
 from core.addr import int_to_addr
 from core.addr import make_mask
@@ -41,6 +22,25 @@ from core.settings import IPCAT_URL
 from core.settings import ROOT_DIR
 from core.settings import TRAILS_FILE
 from core.settings import USERS_DIR
+"""
+Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+See the file 'LICENSE' for copying permission
+"""
+
+import csv
+import glob
+import inspect
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+import urllib2
+
+sys.dont_write_bytecode = True
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))  # to enable calling from current directory too
+
 
 # patch for self-signed certificates (e.g. CUSTOM_TRAILS_URL)
 try:

--- a/sensor.py
+++ b/sensor.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python2
 
-"""
-Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
-See the file 'LICENSE' for copying permission
-"""
-
-from __future__ import print_function  # Requires: Python >= 2.6
-
-import sys
-
-sys.dont_write_bytecode = True
-
 import core.versioncheck
-
 import inspect
 import math
 import mmap
@@ -28,7 +16,6 @@ import time
 import traceback
 import urllib
 import urlparse
-
 from core.addr import inet_ntoa6
 from core.attribdict import AttribDict
 from core.common import check_connection
@@ -89,6 +76,19 @@ from core.settings import WHITELIST_HTTP_REQUEST_PATHS
 from core.settings import WHITELIST_UA_KEYWORDS
 from core.update import update_ipcat
 from core.update import update_trails
+"""
+Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+See the file 'LICENSE' for copying permission
+"""
+
+from __future__ import print_function  # Requires: Python >= 2.6
+
+import sys
+
+sys.dont_write_bytecode = True
+
+
+
 
 _buffer = None
 _caps = []

--- a/server.py
+++ b/server.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python2
 
-"""
-Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
-See the file 'LICENSE' for copying permission
-"""
-
-from __future__ import print_function  # Requires: Python >= 2.6
-
-import sys
-
-sys.dont_write_bytecode = True
-
 import core.versioncheck
-
 import optparse
 import os
 import platform
@@ -20,7 +8,6 @@ import subprocess
 import threading
 import time
 import traceback
-
 from core.common import check_connection
 from core.common import check_sudo
 from core.httpd import start_httpd
@@ -35,6 +22,19 @@ from core.settings import NAME
 from core.settings import VERSION
 from core.update import update_ipcat
 from core.update import update_trails
+"""
+Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+See the file 'LICENSE' for copying permission
+"""
+
+from __future__ import print_function  # Requires: Python >= 2.6
+
+import sys
+
+sys.dont_write_bytecode = True
+
+
+
 
 def main():
 


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.