### PR TITLE
Fixed 4 issues of type: PYTHON_W291 throughout 2 files in repo.

### DIFF
--- a/core/ignore.py
+++ b/core/ignore.py
@@ -27,6 +27,6 @@ def ignore_event(event_tuple):
         break
 
     if retval and config.SHOW_DEBUG:
-        print("[i] ignore_event src_ip=%s, src_port=%s, dst_ip=%s, dst_port=%s" % (src_ip, src_port, dst_ip, dst_port)) 
+        print("[i] ignore_event src_ip=%s, src_port=%s, dst_ip=%s, dst_port=%s" % (src_ip, src_port, dst_ip, dst_port))
 
     return retval

--- a/core/settings.py
+++ b/core/settings.py
@@ -386,9 +386,9 @@ def read_whitelist():
                 else:
                     WHITELIST.add(line)
                     
-# add rules to ignore event list from passed file                
+# add rules to ignore event list from passed file
 def add_ignorelist(filepath):
-    if filepath and os.path.isfile(filepath):         
+    if filepath and os.path.isfile(filepath):
         with open(filepath, "r") as f:
             for line in f:
                 line = re.sub(r"\s+", "", line)
@@ -406,7 +406,7 @@ def read_ignorelist():
     add_ignorelist(_)
                         
     if config.USER_IGNORELIST and os.path.isfile(config.USER_IGNORELIST):
-        add_ignorelist(config.USER_IGNORELIST)  
+        add_ignorelist(config.USER_IGNORELIST)
     
 def read_ua():
     global SUSPICIOUS_UA_REGEX


### PR DESCRIPTION
PYTHON_W291: 'Remove trailing whitespace.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.