### PR TITLE
Fixed 1 issue of type: PYTHON_W391 throughout 1 file in repo.

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -493,4 +493,3 @@ if __name__ != "__main__":
     read_worst_asn()
     read_cdn_ranges()
     read_bogon_ranges()
-


### PR DESCRIPTION
PYTHON_W391: 'blank line at end of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.