### PR TITLE
Update malicious_php.txt

### DIFF
--- a/trails/static/suspicious/malicious_php.txt
+++ b/trails/static/suspicious/malicious_php.txt
@@ -29,14 +29,6 @@
 
 /loomistech/gate.php
 
-# Reference: https://twitter.com/James_inthe_box/status/1044957343568388097
-# Reference: https://pastebin.com/st49wnwB
-# Reference: https://pastebin.com/bPV4gVVL
-
-/4/forum.php
-/d2/forum.php
-/mlu/forum.php
-
 # Reference: https://twitter.com/nullcookies/status/1019569151503986689
 
 /bc0de.php

--- a/trails/static/suspicious/malicious_php.txt
+++ b/trails/static/suspicious/malicious_php.txt
@@ -162,3 +162,9 @@ statconuter.com/c.php
 # Reference: https://twitter.com/ViriBack/status/1114610878056402945
 
 /class-walker-page-up.php
+
+# Reference: http://marketplace.1c-bitrix.ru/blog/remove-virus-miner-from-the-site-to-1cbitrix/ (RU-lang)
+# Generic detection for compromised Bitrix CMS
+
+/bitrix/tools/check_files.php
+/bitrix/gadgets/bitrix/weather/lang/ru/exec/include.php


### PR DESCRIPTION
As an additional semaphores to ```# Generic detection for compromised Bitrix CMS``` trails, which are present in ```malicious_js.txt``` (https://github.com/stamparm/maltrail/commit/67e0071f11e45ce7b53fd2412f01f25c05a8d3c2). Normally, files ```/bitrix/tools/check_files.php``` and ```/bitrix/gadgets/bitrix/weather/lang/ru/exec/include.php``` are absent on non-compromised Bitrix CMS-es out-of-the-box and, if they are present _by_these_specific_pathes_only_, this means, that Bitrix CMS is currently compromised. I missed to add them last time. :( This patch should fix it.