### PR TITLE
Create apt_docless.txt

### DIFF
--- a/trails/static/malware/apt_docless.txt
+++ b/trails/static/malware/apt_docless.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/teoseller/status/1118119539525455874
+# Reference: https://blog.en.elevenpaths.com/2019/04/new-research-docless-vietnam-apt.html
+# Reference: https://www.virustotal.com/gui/ip-address/144.202.54.86/relations
+
+http://144.202.54.86
+144.202.54.86:443


### PR DESCRIPTION
Single trail, no other ways to detect.