### PR TITLE
Update apt_kimsuky.txt

### DIFF
--- a/trails/static/malware/apt_kimsuky.txt
+++ b/trails/static/malware/apt_kimsuky.txt
@@ -32,5 +32,4 @@ seoulhobi.biz
 
 # Generic trails (also can be met in https://unit42.paloaltonetworks.com/babyshark-malware-part-two-attacks-continue-using-kimjongrat-and-pcrat/)
 
-/cow.php
 /expres.php

--- a/trails/static/malware/apt_kimsuky.txt
+++ b/trails/static/malware/apt_kimsuky.txt
@@ -20,8 +20,6 @@ safe-naver-mail.pe.hu
 # Reference: https://blog.alyac.co.kr/2234 (Korean)
 
 tcjst.com
-/com/cow.php
-/com/expres.php
 
 # Reference: https://twitter.com/blackorbird/status/1118334122592591872
 # Reference: https://raw.githubusercontent.com/blackorbird/APT_REPORT/master/kimsuky/Smoke%20Screen.pdf
@@ -31,13 +29,8 @@ tcjst.com
 http://192.186.142.74
 192.186.142.74:81
 seoulhobi.biz
-/cache/cow.php
-/cache/expres.php
-/common/cow.php
-/common/expres.php
-/view/cow.php
-/view/expres.php
-/891250/cow.php
-/891250/expres.php
-/NEACD/cow.php
-/NEACD/expres.php
+
+# Generic trails (also can be met in https://unit42.paloaltonetworks.com/babyshark-malware-part-two-attacks-continue-using-kimjongrat-and-pcrat/)
+
+/cow.php
+/expres.php


### PR DESCRIPTION
Now these generic trails can easily be harder, without any fear of FPs. They also can be met in https://unit42.paloaltonetworks.com/babyshark-malware-part-two-attacks-continue-using-kimjongrat-and-pcrat/ (See ```Figure 2. BabyShark malware overall structure```). Will also placed in ```apt_stolenpencil.txt```. Redundant a little bit, but gives a nice illustration what exact APTs use this malware.