### PR TITLE
Update danabot.txt (removing FPs)

### DIFF
--- a/trails/static/malware/danabot.txt
+++ b/trails/static/malware/danabot.txt
@@ -55,4 +55,4 @@ traderssoftware.info
 
 # Reference: https://twitter.com/James_inthe_box/status/1122156673299173377
 
-/ponto.php
+frezyderm-orders.gr/sites/all/notused/not/ponto.php


### PR DESCRIPTION
Generic trail gives FPs (e.g. ```http://www.teiaidentificacao.com.br/ponto.php```). So, full-path instead.