### PR TITLE
Create kryptonstealer.txt

### DIFF
--- a/trails/static/malware/kryptonstealer.txt
+++ b/trails/static/malware/kryptonstealer.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/James_inthe_box/status/1124278816753442818
+
+tapok121.jhfree.net
+/connect_meta.php


### PR DESCRIPTION
Generic trail is OK to add due to Google.