### PR TITLE
Create gh0stcringe.txt

### DIFF
--- a/trails/static/malware/gh0stcringe.txt
+++ b/trails/static/malware/gh0stcringe.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/James_inthe_box/status/1125086520229056512
+# Reference: https://twitter.com/James_inthe_box/status/1125088799007039488
+
+power888.tpddns.cn
+212951jh19.iok.la
+fget-career.com
+183.93.120.236:1009


### PR DESCRIPTION
```tpddns.cn``` is also placed in ```dynamic_domain.txt```: https://github.com/stamparm/maltrail/pull/1773/commits/4899490b69dc66b8c678a4da77b39d4a2e346cf0