### PR TITLE
Update domain.txt

### DIFF
--- a/trails/static/suspicious/domain.txt
+++ b/trails/static/suspicious/domain.txt
@@ -4959,6 +4959,6 @@ zik.dj
 
 iok.la
 
-# Reference: # Reference: https://www.ptsecurity.com/ru-ru/research/analytics/operation-taskmasters-2019/ (Russian)
+# Reference: https://www.ptsecurity.com/ru-ru/research/analytics/operation-taskmasters-2019/ (Russian)
 
 5wya.com

--- a/trails/static/suspicious/domain.txt
+++ b/trails/static/suspicious/domain.txt
@@ -4958,3 +4958,7 @@ zik.dj
 # Reference: https://www.virustotal.com/gui/domain/iok.la/relations
 
 iok.la
+
+# Reference: # Reference: https://www.ptsecurity.com/ru-ru/research/analytics/operation-taskmasters-2019/ (Russian)
+
+5wya.com

--- a/trails/static/suspicious/domain.txt
+++ b/trails/static/suspicious/domain.txt
@@ -4962,3 +4962,8 @@ iok.la
 # Reference: https://www.ptsecurity.com/ru-ru/research/analytics/operation-taskmasters-2019/ (Russian)
 
 5wya.com
+
+# Reference: https://securelist.com/scarcruft-continues-to-evolve-introduces-bluetooth-harvester/90729/
+# Reference: https://www.virustotal.com/gui/domain/nitesbr1.org/details
+
+nitesbr1.org


### PR DESCRIPTION
Almost all trails in #1907 use dynamic domains, but I'm not strongly sure, that ```5wya.com``` is dynamic one, because there's no much info about this domain. Due to graphs on VT, this domain leads to CN and HK only. And this domain is marked as one of actors-participants of attack in ```ptsecurity``` survey. So, let him live in ```domain.txt``` trail.

UPD: Or even to place all these proposed domains to ```bad_history.txt``` trail...