### PR TITLE
Update apt_sofacy.txt

### DIFF
--- a/trails/static/malware/apt_sofacy.txt
+++ b/trails/static/malware/apt_sofacy.txt
@@ -1529,5 +1529,7 @@ systembeforeniceparent.com
 
 # Reference: https://securelist.com/zebrocys-multilanguage-malware-salad/90680/
 
+http://94.156.189.120
 rammatica.com
 raveston.com
+/manual/current/symphony.php

--- a/trails/static/malware/apt_sofacy.txt
+++ b/trails/static/malware/apt_sofacy.txt
@@ -1526,3 +1526,8 @@ reasonwithusefulpolicy.com
 schooltillhungryprocess.com
 streetunderrelevantpeople.com
 systembeforeniceparent.com
+
+# Reference: https://securelist.com/zebrocys-multilanguage-malware-salad/90680/
+
+rammatica.com
+raveston.com


### PR DESCRIPTION
```Several months later, a Zebrocy backdoor connected back to a domain that was registered by a particular email address. This address had been used to register another Sofacy domain hosted on a well-known Sofacy IP at the time (rammatica[.]com/raveston[.]com).```