### PR TITLE
Create sysrat.txt

### DIFF
--- a/trails/static/malware/sysrat.txt
+++ b/trails/static/malware/sysrat.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Aliases: runningrat, sysrat
+
+# Reference: https://securingtomorrow.mcafee.com/other-blogs/mcafee-labs/gold-dragon-widens-olympics-malware-attacks-gains-permanent-presence-on-victims-systems/
+
+http://200.200.200.13
+http://223.194.70.136


### PR DESCRIPTION
```After the second DLL is loaded into memory, the first DLL overwrites the IP address for the control server, effectively changing the address the malware will communicate with. This address is hardcoded in the second DLL as 200.200.200.13 and is modified by the first DLL to 223.194.70.136.```