### PR TITLE
Update elf_generic.txt

### DIFF
--- a/trails/static/malware/elf_generic.txt
+++ b/trails/static/malware/elf_generic.txt
@@ -45,8 +45,10 @@ cyberium.xyz
 http://54.37.70.249
 
 # Reference: https://twitter.com/bad_packets/status/1134920520644714496
+# Reference: https://twitter.com/bad_packets/status/1140065934926684162
 
 45.79.9.153:8000
+110.40.14.13:8000
 
 # Reference: https://twitter.com/bad_packets/status/1135623419670646784
 
@@ -65,7 +67,3 @@ http://46.22.220.21
 5.255.86.129:3333
 /.satan
 /.x15cache
-
-# Reference: https://twitter.com/bad_packets/status/1140065934926684162
-
-110.40.14.13:8000

--- a/trails/static/malware/elf_generic.txt
+++ b/trails/static/malware/elf_generic.txt
@@ -54,8 +54,10 @@ http://54.37.70.249
 
 # Misc.
 
+http://173.212.214.137
 http://46.22.220.21
 45.32.200.190:443
+85.25.84.99:443
 
 # Reference: https://otx.alienvault.com/pulse/5d020fb5a91466d30ad51fa2
 

--- a/trails/static/malware/elf_generic.txt
+++ b/trails/static/malware/elf_generic.txt
@@ -56,3 +56,10 @@ http://54.37.70.249
 
 http://46.22.220.21
 45.32.200.190:443
+
+# Reference: https://otx.alienvault.com/pulse/5d020fb5a91466d30ad51fa2
+
+146.185.171.227:443
+5.255.86.129:3333
+/.satan
+/.x15cache

--- a/trails/static/malware/elf_generic.txt
+++ b/trails/static/malware/elf_generic.txt
@@ -65,3 +65,7 @@ http://46.22.220.21
 5.255.86.129:3333
 /.satan
 /.x15cache
+
+# Reference: https://twitter.com/bad_packets/status/1140065934926684162
+
+110.40.14.13:8000

--- a/trails/static/malware/elf_generic.txt
+++ b/trails/static/malware/elf_generic.txt
@@ -51,3 +51,8 @@ http://54.37.70.249
 # Reference: https://twitter.com/bad_packets/status/1135623419670646784
 
 216.176.179.106:9090
+
+# Misc.
+
+http://46.22.220.21
+45.32.200.190:443


### PR DESCRIPTION
Working on ```elf_hacked_exim.txt``` trail (#2286 ), have found bash-loader ```173.212.214.137/b``` with addresses, which can be marked as ```elf_generic.txt```.