### PR TITLE
Create malicious_egg.txt

### DIFF
--- a/trails/static/suspicious/malicious_egg.txt
+++ b/trails/static/suspicious/malicious_egg.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://blog.alyac.co.kr/2347
+
+/ChromSrch.egg
+/GoogleRsv.egg
+/HncCheck.egg
+/IEService.egg


### PR DESCRIPTION
Additional trail for https://github.com/stamparm/maltrail/pull/2316/commits/2f1155d6c0e6419498f8366f01051eb58127a484

The logic and goal are the same to ```malicious_hta``,  ```malicious_ps1``` trails and so on.