### PR TITLE
Update rogue_dns.txt

### DIFF
--- a/trails/static/suspicious/rogue_dns.txt
+++ b/trails/static/suspicious/rogue_dns.txt
@@ -68,3 +68,9 @@ ns2.firstdnshoster.com
 185.209.160.70:53
 190.2.147.146:53
 31.148.219.110:53
+
+# Reference: https://habr.com/ru/company/bizone/blog/456804/ (Russian)
+
+188.165.200.156:53
+217.12.210.54:53
+91.217.137.37:53


### PR DESCRIPTION
```Из декомпилированного кода одного из экземпляров видно, что для разрешения доменного имени C&C используется специальный DNS-сервер 188.165[.]200.156. А в случае неудачи используется список из трех DNS-серверов: 91.217[.]137.37, 188.165[.]200.156, 217.12[.]210.54``` --> ```One can see in decompiled code, that special DNS-server 188.165[.]200.156 is in use to resolve domain name of C&C. If fail, DNS-servers list 91.217[.]137.37, 188.165[.]200.156, 217.12[.]210.54 is applied.```