### PR TITLE
Update osx_mami.txt

### DIFF
--- a/trails/static/malware/osx_mami.txt
+++ b/trails/static/malware/osx_mami.txt
@@ -3,8 +3,6 @@
 
 # Reference: https://www.intego.com/mac-security-blog/ay-mami-new-dns-hijacking-mac-malware-discovered/
 
-82.163.143․135
-82.163.142․137
 squartera.info
 gorensin.info
 honouncil.info


### PR DESCRIPTION
Moving to ```rogue_dns.txt```: #2785 via ```Affected users should should first check whether the DNS servers on a  Mac are set to 82.163.143.135 and 82.163.142.137``` (https://www.scmagazineuk.com/new-mac-malware-mami-hijacks-dns-connections/article/1473476)