### PR TITLE
Create ad_network.txt

### DIFF
--- a/trails/static/suspicious/ad_network.txt
+++ b/trails/static/suspicious/ad_network.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://decoded.avast.io/threatintel/router-exploit-kits-an-overview-of-routercsrf-attacks-and-dns-hijacking-in-brazil/
+
+bodelen.com
+dolohen.com
+popcash.net
+rotumal.com


### PR DESCRIPTION
Reason of creating this trail: ```RouterCSRF campaigns are often distributed via malvertising campaigns through popcash[.]net, dolohen[.]com, rotumal[.]com, bodelen[.]com and other ad rotators, and appear in waves.```