### PR TITLE
Update azorult.txt

### DIFF
--- a/trails/static/malware/azorult.txt
+++ b/trails/static/malware/azorult.txt
@@ -656,3 +656,23 @@ testaztest.xyz
 # Reference: https://twitter.com/James_inthe_box/status/1164898833500798976
 
 losjardinesdejavier.com/admin/32/index.php
+
+# Reference: https://twitter.com/DynamicAnalysis/status/1165720711219929088
+# Reference: https://pastebin.com/wHV90Sc2
+
+http://151.80.8.23/panel/index.php
+http://185.222.56.163/index.php
+http://23.227.201.16/gidi/index.php
+http://92.63.192.119/index.php
+a0327852.xsph.ru
+a0329841.xsph.ru
+cdl24885oq.temp.swtest.ru
+kilangsprcoket.tk
+latiso.ru
+modcloudserver.eu
+roberto.ac.ug
+testaztest.xyz
+testieng.kl.com.ua
+u4504124br.ha003.t.justns.ru
+lakeshoreintegrated.com/ch/index.php
+xcvcdgfg.ru


### PR DESCRIPTION
```lakeshoreintegrated.com``` looks as compromised site. So, full path only.