### PR TITLE
Fail and log on unknown DLT packet

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -940,7 +940,11 @@ def monitor():
         global _count
 
         ip_offset = None
-        dlt_offset = DLT_OFFSETS[datalink]
+	try:
+            dlt_offset = DLT_OFFSETS[datalink]
+        except KeyError:
+	    log_error("Received unexpected datalink (%d)" % datalink)
+	    return
 
         try:
             if datalink == pcapy.DLT_RAW:


### PR DESCRIPTION
Fixes https://github.com/stamparm/maltrail/issues/3570

USB should never show up on the network, so it doesn't need to be processed, but log it. 