### PR TITLE
Delete camscanner_backdoor.txt

### DIFF
--- a/trails/static/malware/camscanner_backdoor.txt
+++ b/trails/static/malware/camscanner_backdoor.txt
@@ -1,9 +1,0 @@
-# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
-# See the file 'LICENSE' for copying permission
-
-# Reference: https://securelist.com/dropper-in-google-play/92496/
-
-abc.abcdserver.com
-bcd.abcdserver.com
-cba.abcdserver.com
-bcd.abcdserver.com


### PR DESCRIPTION
Was added far ago: https://github.com/stamparm/maltrail/blob/master/trails/static/malware/android_camscanner.txt