### PR TITLE
Update jigsaw.txt

### DIFF
--- a/trails/static/malware/jigsaw.txt
+++ b/trails/static/malware/jigsaw.txt
@@ -5,7 +5,3 @@
 # Reference: https://www.virustotal.com/gui/file/80bc27ef05d51164ba3a66e6353a84e9c91de6f9961a15c99afe47be7a16e10b/detection
 
 demourl.co.nf
-
-# Generic
-
-/pwd/write.php


### PR DESCRIPTION
Leaving ```/pwd/write.php?info=``` for ```malicious_php``` while other (non-jigsaw) malwares can be covered.