### PR TITLE
Create pinkslipbot.txt

### DIFF
--- a/trails/static/malware/pinkslipbot.txt
+++ b/trails/static/malware/pinkslipbot.txt
@@ -2,5 +2,29 @@
 # See the file 'LICENSE' for copying permission
 
 # Reference: https://securingtomorrow.mcafee.com/other-blogs/mcafee-labs/mcafee-discovers-pinkslipbot-exploiting-infected-machines-as-control-servers-releases-free-tool-to-detect-disable-trojan/
+# Reference: https://www.mcafee.com/enterprise/en-us/assets/solution-briefs/sb-quarterly-threats-may-2016-2.pdf
+
+bbxrsgsuwksogpktqydlkh.net
+dxmhcvxcmdewthfbnaspnu.org
+enwgzzthfwhdm.org
+feqsrxswnumbkh.com
+gpfbvtuz.org
+gyvwkxfxqdargdooqql.net
+hogfpicpoxnp.org
+hsdmoyrkeqpcyrtw.biz
+ivalhlotxdyvzyxrb.net
+jynsrklhmaqirhjrtygjx.biz
+lgzmtkvnijeaj.biz
+mfrlilcumtwieyzbfdmpdd.biz
+mwtfngzkadeviqtlfrrio.org
+nykhliicqv.org
+qrogmwmahgcwil.com
+rudjqypvucwwpfejdxqsv.org
+tqxllcfn.com
+uuwgdehizcuuucast.com
+vksslxpxaoql.com
+xwcjchzq.com
+
+# Generic trails
 
 /bot_serv

--- a/trails/static/malware/pinkslipbot.txt
+++ b/trails/static/malware/pinkslipbot.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://securingtomorrow.mcafee.com/other-blogs/mcafee-labs/mcafee-discovers-pinkslipbot-exploiting-infected-machines-as-control-servers-releases-free-tool-to-detect-disable-trojan/
+
+/bot_serv


### PR DESCRIPTION
The second attempt. The single normal applicable sign is ```/bot_serv```. See snippet in article:

```
If any port-forwarding request succeeds (and if other open ports are found), the malware saves the port number into a buffer and removes the port-mapping rule. The port-forwarding results are submitted to the control server using an HTTP POST request:

URL: hxxps://{control server-IP-Address}:{Port}/bot_serv
POST-DATA:
cmd=1&msg={obfuscated-string}&ports=993,80,465,21,50000,61200,61202
````

Google says OK to have such one: ``` inurl:"/bot_serv"```