### PR TITLE
Update winnti.txt

### DIFF
--- a/trails/static/malware/winnti.txt
+++ b/trails/static/malware/winnti.txt
@@ -66,7 +66,16 @@ ap.nhntech.com
 
 goog1eupdate.com
 
-
 # Reference: https://twitter.com/daphiel/status/1162875379872387075
 
 google-searching.com
+
+# Reference: https://www.welivesecurity.com/wp-content/uploads/2019/10/ESET_Winnti.pdf
+# Reference: https://otx.alienvault.com/pulse/5da4528788ac7149ce4894b7
+
+dns1-1.7release.com
+ssl.dyn-dns.co
+ssl.dyn-dns.com
+svn-dns.ahnlabinc.com
+xp101.dyn-dns.co
+xp101.dyn-dns.com


### PR DESCRIPTION
ESET's survey has a typo: either in ```7.4``` section or in ```11.3```: ```.co <-> .com``` in domain names. I put both of variations to trail. Root domains will go to ```domain.txt```, because they seem not to be dynamic.