### PR TITLE
Create blackremoterat.txt

### DIFF
--- a/trails/static/malware/blackremoterat.txt
+++ b/trails/static/malware/blackremoterat.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://unit42.paloaltonetworks.com/blackremote-money-money-money-a-swedish-actor-peddles-an-expensive-new-rat/
+
+blackremote.pro
+speccy.dev


### PR DESCRIPTION
C2 is covered by ```nanocore.txt``` trail far long ago.