### PR TITLE
Create osx_bundlore.txt

### DIFF
--- a/trails/static/malware/osx_bundlore.txt
+++ b/trails/static/malware/osx_bundlore.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2014-2019 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Aliases: bundlore loader, surfbuyer
+
+# Reference: https://blog.confiant.com/new-macos-bundlore-loader-analysis-ca16d19c058c
+# Reference: https://otx.alienvault.com/pulse/5df796363d73907fec7cd95c
+
+appsdown.urbanvillager.xyz


### PR DESCRIPTION
Root ```urbanvillager.xyz``` will go to generic.