### PR TITLE
Update android_roamingmantis.txt

### DIFF
--- a/trails/static/malware/android_roamingmantis.txt
+++ b/trails/static/malware/android_roamingmantis.txt
@@ -1007,6 +1007,8 @@ bank-securityw.com
 
 # Generic trails
 
+^[a-z]{1}\-[a-z]{1,3}\.top$
+^[a-z]{2}\-[a-z]{2,3}\.(top|club)$
 www\.[a-z]{1}\-[a-z]{1,3}\.top$
 www\.[a-z]{2}\-[a-z]{2,3}\.(top|club)$
 apple\-icloud\.[a-z]{3}\-japan\.com


### PR DESCRIPTION
Reverting https://github.com/stamparm/maltrail/commit/5ea3c04d825a8418268c28c1ad405ab714f489dd 

It is meaningless to lose detection for tons of real ```android_roamingmantis``` domains for game of 10 and even 100 FPs: I'll put all of them to ```whitelist.txt``` trail (as it was done in https://github.com/stamparm/maltrail/commit/58eb5826c40c66a57519c7a534bf81d521c3c984) with my own hands -- just merely give me such list of legit domains, which are covered by ```android_roamingmantis``` regex. Thanks!