### PR TITLE
Update apt_unclassified.txt

### DIFF
--- a/trails/static/malware/apt_unclassified.txt
+++ b/trails/static/malware/apt_unclassified.txt
@@ -586,3 +586,13 @@ domain-lk.sytes.net
 foreign-mv.sytes.net
 ncit-gov.sytes.net
 windefupdate.sytes.net
+
+# Reference: https://twitter.com/kyleehmke/status/1207779048086286336
+# Reference: https://twitter.com/kyleehmke/status/1216905172305227776
+
+cubenergy-my-sharepoint.com
+dpkshodnya-mysharepoint.com
+kub-gas.com
+kvatral95.com
+minjust-gov-ua.com
+my-ukr.net


### PR DESCRIPTION
This looks as TA505-based domain names structure, but I'm not really sure it is TA505 in fact. Or FacyBear, or anything else. While being with no explicit classification, I'm gonna put such cases to ```apt_unclassified.txt```. Also moving here the similar domain from ```domain.txt``` trail.