### PR TITLE
Create bdf_injector.txt

### DIFF
--- a/trails/static/malware/bdf_injector.txt
+++ b/trails/static/malware/bdf_injector.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2014-2020 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/SBousseaden/status/1221562146573758472
+# Reference: https://app.any.run/tasks/2f64ab4f-b405-4462-830c-03cbdf475216/
+# Reference: https://www.virustotal.com/gui/ip-address/87.57.141.215/relations
+# Reference: https://www.virustotal.com/gui/file/082eff8046385cb9233ddd792d4e118c9834a8a11cf4d980b4279ec5aeb53968/detection
+# Reference: https://www.virustotal.com/gui/file/aaa246dfe7122fcb872ec5298b9fd53aa50486bfb4107db70c1fbfca112218c4/detection
+
+87.57.141.215:443


### PR DESCRIPTION
Do not want to put it to ```generic```. Name is based on Kaspersky's detection (```Packed.Win32.BDF.a```) and behaviour of the packer itself (```Malware-Cryptor.Inject.gen```).