### PR TITLE
Update fareit.txt

### DIFF
--- a/trails/static/malware/fareit.txt
+++ b/trails/static/malware/fareit.txt
@@ -441,13 +441,11 @@ frteary.ru
 
 # Reference: https://app.any.run/tasks/c2520065-cc72-4acf-addd-ddf61f9c0488/
 
-http://195.123.240.67/p/g_38472341.php
-http://195.123.240.67/viewtopic.php
+http://195.123.240.67
 
 # Reference: https://app.any.run/tasks/18bd5b34-e5c0-40aa-9eaa-ed86cca12a5f/
 
-http://45.90.57.16/p/g_38472341.php
-http://45.90.57.16/viewtopic.php
+http://45.90.57.16
 
 # Generic trails (heur)
 


### PR DESCRIPTION
```/p/g_38472341.php``` sign lives in ```#Generic``` already for hundreds of years and covers all such cases for IPs, that are not in list . ```/viewtopic.php``` tail is too generic. Generalizing detection to be free of detection, if such tail will be  changed by its authors, and MT won't lose detection here.