### PR TITLE
Update bad_service.txt

### DIFF
--- a/trails/static/malicious/bad_service.txt
+++ b/trails/static/malicious/bad_service.txt
@@ -353,5 +353,4 @@ hotaction.online
 # Reference: https://twitter.com/ps66uk/status/1228268374649659392
 # Reference: https://app.any.run/tasks/9be4f8eb-e828-4ca5-ba76-6f8db7f1627a/
 
-107.189.7.176:80
 crypters.info

--- a/trails/static/malicious/bad_service.txt
+++ b/trails/static/malicious/bad_service.txt
@@ -349,3 +349,9 @@ cardplanet.cc
 # Reference: https://www.virustotal.com/gui/domain/hotaction.online/relations
 
 hotaction.online
+
+# Reference: https://twitter.com/ps66uk/status/1228268374649659392
+# Reference: https://app.any.run/tasks/9be4f8eb-e828-4ca5-ba76-6f8db7f1627a/
+
+107.189.7.176:80
+crypters.info


### PR DESCRIPTION
```107.189.7.176``` returns ```crypters.info```, but if to put ```http://107.189.7.176/crypter/``` -- it returns subfolders, which can contain POST-ed info from backdoors. Simultaneously ```crypters.info``` is not malicious by itself. So -- ```bad_service.txt```.