### PR TITLE
Update ursnif.txt

### DIFF
--- a/trails/static/malware/ursnif.txt
+++ b/trails/static/malware/ursnif.txt
@@ -2233,10 +2233,6 @@ lapenik.at
 g4xp7aanksu6qgci.onion
 l35sr5h5jl7xrh2q.onion
 
-# Reference: https://twitter.com/reecdeep/status/1229674592068866048
-
-mengather.com
-
 # Generic trails
 
 /%20%20%20%20.php

--- a/trails/static/malware/ursnif.txt
+++ b/trails/static/malware/ursnif.txt
@@ -2233,6 +2233,10 @@ lapenik.at
 g4xp7aanksu6qgci.onion
 l35sr5h5jl7xrh2q.onion
 
+# Reference: https://twitter.com/reecdeep/status/1229674592068866048
+
+mengather.com
+
 # Generic trails
 
 /%20%20%20%20.php
@@ -2284,6 +2288,7 @@ l35sr5h5jl7xrh2q.onion
 /paginfo52.php
 /paginfo83.php
 /pagioiu88.php
+/pagkit56.php
 /pagkype32.php
 /pagnuko56.php
 /pagnupo27.php


### PR DESCRIPTION
Despite on being declared as ```ransomware``` (without name) and having tail ```/pagkit56.php```, which  is very similar to ```ursnif```-based variations, let it all live in ```ursnif.txt```.