### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,6 @@ This software is provided under a MIT License. See the accompanying [LICENSE](ht
 * [FreeBSD Port](https://www.freshports.org/security/maltrail)
 * [OPNSense Gateway Plugin](https://github.com/opnsense/plugins/pull/1241)
 * [D4 Project](https://www.d4-project.org/2019/09/25/maltrail-integration.html)
-* [Jigsaw Security EMM Solution](https://www.jigsawsecurityenterprise.com/single-post/2017/10/30/Elasticsearch-MISP-and-Maltrail-Integration)
+* [Jigsaw Security EMM Solution](https://github.com/jigsawsecurity/Maltrail-1)
 * [GScan](https://github.com/grayddq/GScan)
 * [BlackArch Linux](https://github.com/BlackArch/blackarch/blob/master/packages/maltrail/PKGBUILD)

--- a/README.md
+++ b/README.md
@@ -632,6 +632,6 @@ This software is provided under a MIT License. See the accompanying [LICENSE](ht
 * [FreeBSD Port](https://www.freshports.org/security/maltrail)
 * [OPNSense Gateway Plugin](https://github.com/opnsense/plugins/pull/1241)
 * [D4 Project](https://www.d4-project.org/2019/09/25/maltrail-integration.html)
-* [Jigsaw Security EMM Solution](https://github.com/jigsawsecurity/Maltrail-1)
+* [Jigsaw Security EMM Solution](https://www.jigsawsecurityenterprise.com/blog-1/2018/01/19/an-overview-of-jigsaw-sensor-technology)
 * [GScan](https://github.com/grayddq/GScan)
 * [BlackArch Linux](https://github.com/BlackArch/blackarch/blob/master/packages/maltrail/PKGBUILD)


### PR DESCRIPTION
Previous news-link now gives 404. Weird, but fact. Putting link on Jigsaw Security Github repo instead.