### PR TITLE
Update magentocore.txt

### DIFF
--- a/trails/static/malicious/magentocore.txt
+++ b/trails/static/malicious/magentocore.txt
@@ -1608,7 +1608,6 @@ y5.ms
 # Reference: https://www.virustotal.com/gui/domain/wp-includ.com/relations
 # Reference: https://twitter.com/500mk500/status/1235330678700548098
 
-ldfidfa.pw
 reportgns.com
 sucuritester.com
 wp-includ.com


### PR DESCRIPTION
Moved to ```buer.txt``` (https://github.com/stamparm/maltrail/pull/7216) due to: https://securelist.com/mokes-and-buerak-distributed-under-the-guise-of-security-certificates/96324/