### PR TITLE
Remove FP secure-magenta1.be2bill.com from magentocore.txt

### DIFF
--- a/trails/static/malicious/magentocore.txt
+++ b/trails/static/malicious/magentocore.txt
@@ -775,10 +775,6 @@ theresevit.com
 
 googlemgrteg.com
 
-# Reference: https://twitter.com/jknsCo/status/1200372639895826432
-
-secure-magenta1.be2bill.com
-
 # Reference: https://twitter.com/eComscan/status/1200749626988662784
 
 sanguinelab.net


### PR DESCRIPTION
This domain is owned by the payment processor Dalenys Payment and has been in use since 2011 http://whois.domaintools.com/be2bill.com

From the source (https://twitter.com/jknsCo/status/1200371937324740609/photo/3), the skimmer is served from `sixthjune.com`, submits credentials to `103.139.113.34` then redirects to `secure-magenta1.be2bill.com` which is the real payment gateway