### PR TITLE
Update dridex.txt

### DIFF
--- a/trails/static/malware/dridex.txt
+++ b/trails/static/malware/dridex.txt
@@ -441,3 +441,8 @@ lupingol.com
 89.107.129.122:4143
 91.211.88.122:443
 91.103.2.132:4543
+
+# Reference: https://twitter.com/JayTHL/status/1237384903181897729
+# Reference: https://twitter.com/JayTHL/status/1237398536687362048
+
+/esdfrtDERGTYuicvbnTYUv/


### PR DESCRIPTION
Generic trail. Domains are in ```generic```, because other, non-dridex, exe-s could be also met.