### PR TITLE
Update apt_unclassified.txt

### DIFF
--- a/trails/static/malware/apt_unclassified.txt
+++ b/trails/static/malware/apt_unclassified.txt
@@ -673,3 +673,10 @@ xn--mynavyfedera-occ.org
 xn--navyfderal-36a.com
 xn--navyfedera-j0b.org
 yandex-account-security.com
+
+# Reference: https://twitter.com/ximo_lcg/status/1242298741140250624
+# Reference: https://app.any.run/tasks/642a1b8c-6232-41c0-8c74-0f4513a44599/
+# Reference: https://www.virustotal.com/gui/ip-address/34.247.80.95/relations
+
+javacon.eu
+cdn.javacon.eu


### PR DESCRIPTION
No info on ```javacon.eu``` registrant and it is unreachable from browser. ```cdn.javacon.eu``` displays copy of ```eclipse.org```...