### PR TITLE
Update domain.txt

### DIFF
--- a/trails/static/suspicious/domain.txt
+++ b/trails/static/suspicious/domain.txt
@@ -5037,3 +5037,7 @@ ubibancaa.fun
 # Reference: https://www.virustotal.com/gui/domain/xfuckdate.com/relations
 
 xfuckdate.com
+
+# Reference: https://www.virustotal.com/gui/domain/mireene.com/relations
+
+mireene.com


### PR DESCRIPTION
Many ```apt_kimsuky``` C2s are hosted on ```mireene.com``` -- somesubdomain.```mireene.com```. Not sure for ```mireene.com``` being malicious itself, but connections to this domain should be considered as suspicious.