### PR TITLE
Update apt_tibet.txt

### DIFF
--- a/trails/static/malware/apt_tibet.txt
+++ b/trails/static/malware/apt_tibet.txt
@@ -52,3 +52,25 @@ hy.micrsofts.com
 ip.micrsofts.com
 ly.micorsofts.net
 xdx.hotmal1.com
+
+# Reference: https://www.volexity.com/blog/2020/03/31/storm-cloud-unleashed-tibetan-community-focus-of-highly-targeted-fake-flash-campaign/ (Storm Cloud)
+# Reference: https://otx.alienvault.com/pulse/5e84c248adbbd69f8c569252
+
+airjaldinet.ml
+windows-report.com
+browserservice.zzux.com
+ctmail.dns-dns.com
+designer.dynamic-dns.net
+getadobeflashdownloader.proxydns.com
+install.ddns.info
+loginwebmailnic.dynssl.com
+root20system20macosxdriver.serveusers.com
+roots.dynamic-dns.net
+ubntrooters.serveuser.com
+
+# Reference: https://securelist.com/holy-water-ongoing-targeted-water-holing-attack-in-asia/96311/
+# Reference: https://otx.alienvault.com/pulse/5e83635bf1c0d9b195569252
+
+adobeflash31_install.ddns.info
+sys_andriod20_designer.dynamic-dns.net
+system0_update04driver_roots.dynamic-dns.net


### PR DESCRIPTION
These two campaigns use the same domains: ```airjaldinet.ml```, ```designer.dynamic-dns.net```, ```roots.dynamic-dns.net```, ```roots.dynamic-dns.net```, ```root20system20macosxdriver.serveusers.com``` , ```roots.dynamic-dns.net``` and ```ubntrooters.serveuser.com```.