### PR TITLE
Create collector.txt

### DIFF
--- a/trails/static/malware/collector.txt
+++ b/trails/static/malware/collector.txt
@@ -8,7 +8,3 @@
 
 u6218636a7.ha004.t.justns.ru
 u667503gif.ha004.t.justns.ru
-
-# Generic
-
-/get_data.php?info

--- a/trails/static/malware/collector.txt
+++ b/trails/static/malware/collector.txt
@@ -1,0 +1,14 @@
+# Copyright (c) 2014-2020 Maltrail developers (https://github.com/stamparm/maltrail/)
+# See the file 'LICENSE' for copying permission
+
+# Reference: https://twitter.com/ViriBack/status/1253857638607196162
+# Reference: https://app.any.run/tasks/9d7710ad-18d6-4f1a-8f7f-25a6629049e4/
+# Reference: https://www.virustotal.com/gui/file/eb1280c930b01b6b2930b926bd8b868312b74ab3b450afb2a216e08773b12bb9/detection
+# Reference: https://www.virustotal.com/gui/domain/u6218636a7.ha004.t.justns.ru/relations
+
+u6218636a7.ha004.t.justns.ru
+u667503gif.ha004.t.justns.ru
+
+# Generic
+
+/get_data.php?info


### PR DESCRIPTION
```/get_data.php?info``` is OK to have, instead of ```/get_data.php?id=``` gives vany FPs due to Google