### PR TITLE
Delete telebots.txt

### DIFF
--- a/trails/static/malware/telebots.txt
+++ b/trails/static/malware/telebots.txt
@@ -1,7 +1,0 @@
-# Copyright (c) 2014-2020 Maltrail developers (https://github.com/stamparm/maltrail/)
-# See the file 'LICENSE' for copying permission
-
-# Reference: https://www.welivesecurity.com/2018/10/11/new-telebots-backdoor-linking-industroyer-notpetya/
-
-esetsmart.org
-um10eset.net


### PR DESCRIPTION
We have this stuff in ```apt_sofacy``` and ```apt_telebots```.