### PR TITLE
Update for data leak heur on Android.Fanta

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -88,7 +88,7 @@ SUSPICIOUS_HTTP_REQUEST_REGEXES = (
     ("potential ldap injection", r"\(\|\(\w+=\*"),
     ("potential xss injection", r"<script.*?>|\balert\(|(alert|confirm|prompt)\((\d+|document\.|response\.write\(|[^\w]*XSS)|on(mouseover|error|focus)=[^&;\n]+\("),
     ("potential xxe injection", r"\[<!ENTITY"),
-    ("potential data leakage", r"im[es]i=\d{15}|(mac|sid)=([0-9a-f]{2}:){5}[0-9a-f]{2}|sim=\d{20}|([a-z0-9_.+-]+@[a-z0-9-.]+\.[a-z]+\b.{0,100}){4}|(telnum|telcompany)=[a-zA-Z0-9-]+"),
+    ("potential data leakage", r"divice_admin=\d|im[es]i=\d{15}|(mac|sid)=([0-9a-f]{2}:){5}[0-9a-f]{2}|sim=\d{20}|([a-z0-9_.+-]+@[a-z0-9-.]+\.[a-z]+\b.{0,100}){4}|(number|operator|telnum|telcompany)=[a-zA-Z0-9-]+"),
     ("config file access", r"\.ht(access|passwd)|\bwp-config\.php"),
     ("potential remote code execution", r"\$_(REQUEST|GET|POST)\[|xp_cmdshell|shell_exec|\bping(\.exe)? -[nc] \d+|timeout(\.exe)? /T|tftp -|wget http|curl -O|sh /tmp/|cmd\.exe|/bin/(ba)?sh\b|2>&1|\b(cat|ls) /|chmod [0-7]{3,4}\b|chmod +x\b|nc -l -p \d+|>\s*/dev/null|-d (allow_url_include|safe_mode|auto_prepend_file)|\$\{IFS\}"),
     ("potential directory traversal", r"(\.{2,}[/\\]+){3,}|/etc/(passwd|shadow|issue|hostname)|[/\\](boot|system|win)\.ini|[/\\]system32\b|%SYSTEMROOT%"),


### PR DESCRIPTION
From ```https://www.group-ib.ru/blog/fanta``` (translation from Russian):

```divice_admin – поле определяет, были ли получены права администратора. Если права администратора были получены, поле равно 1, иначе 0```

 -->

```divice_admin – field value defines whenever admin rights are on|off on device. In yes, divice_admin=1, otherwise=0```.

Plus updating telephone number and company\operator parameters: ```mode=register_bot&prefix=2&version_sdk=<%VERSION_SDK%>&imei=<%IMEI%>&country=<%COUNTRY_ISO%>&number=<%TEL_NUMBER%>&operator=<%OPERATOR_NAME%>```.

Related to https://github.com/stamparm/maltrail/pull/8651/commits/d20ed92544fffa1827edd0c89d6b498dde56b02d