### PR TITLE
Update osx_mami.txt

### DIFF
--- a/trails/static/malware/osx_mami.txt
+++ b/trails/static/malware/osx_mami.txt
@@ -13,3 +13,8 @@ definitial.info
 humption.info
 lilovakia.info
 accessful.info
+
+# Reference: https://www.scmagazineuk.com/new-mac-malware-mami-hijacks-dns-connections/article/1473476
+
+82.163.142.137:53
+82.163.143.135:53


### PR DESCRIPTION
Moving ```osx_mami```-related rogue DNS to explicitly named trail.