### PR TITLE
Add web hosting providers associated with malware

### DIFF
--- a/trails/static/suspicious/free_web_hosting.txt
+++ b/trails/static/suspicious/free_web_hosting.txt
@@ -437,3 +437,11 @@ heliohost.org
 # Reference: https://tiiny.host/
 
 tiiny.host
+
+# Reference: https://www.virustotal.com/gui/domain/ftp.totallyanonymous.com/relations
+
+ftp.totallyanonymous.com
+
+# Reference: https://www.scumware.org/report/drivehq.com
+
+drivehq.com


### PR DESCRIPTION
ftp.totallyanonymous.com 
drivehq.com