### PR TITLE
Update ua.txt

### DIFF
--- a/misc/ua.txt
+++ b/misc/ua.txt
@@ -1579,6 +1579,12 @@ PPPPPX
 FunWebProducts
 IE0006_ver1
 
+# Reference: https://us-cert.cisa.gov/ncas/analysis-reports/AR18-352A
+
+Mozilla/5.0 (Windows NT 6.3; rv:48.0) Gecko/20100101 Firefox/48.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A
+Intel Mac OS X 10_9_3
+
 # Misc
 
 information_schema

--- a/misc/ua.txt
+++ b/misc/ua.txt
@@ -1582,8 +1582,6 @@ IE0006_ver1
 # Reference: https://us-cert.cisa.gov/ncas/analysis-reports/AR18-352A
 
 Mozilla/5.0 (Windows NT 6.3; rv:48.0) Gecko/20100101 Firefox/48.0
-Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A
-Intel Mac OS X 10_9_3
 
 # Misc
 


### PR DESCRIPTION
1)
```Mozilla/5.0 (Windows NT 6.3; rv:48.0) Gecko/20100101 Firefox/48.0.

This User-Agent string mimics a Mozilla Firefox 48 browser running on Windows 8.1. This User-Agent string would likely stand out as unique in a corporate network environment, and its presence could be a high-confidence indication of Quasar activity.
```

2)
```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A.

This User-Agent string mimics an Apple Safari 7.0.3 browser running on Mac OS X 10.9.3. The use of Mac OS X as the operating system is interesting because Quasar can only be run on Windows. NCCIC has leveraged Quasar’s use of Mac OS X to limit false positives in the Snort signatures for this activity.
```