### PR TITLE
Update vadokrist.txt

### DIFF
--- a/trails/static/malware/vadokrist.txt
+++ b/trails/static/malware/vadokrist.txt
@@ -15,6 +15,12 @@ http://191.237.255.155
 http://191.239.244.141
 http://191.239.245.87
 http://191.239.255.102
+cloudmx.homelinux.com
+dumblegat.simple-url.com
+javfoms.podzone.org
+jotagot.mypets.ws
+metalpink.serveftp.org
+vemvem.duckdns.org
 
 # Reference: https://twitter.com/wwp96/status/1366485090340077572
 # Reference: https://app.any.run/tasks/e5727887-2bdb-4f37-a1ad-cb43d88a9828/
@@ -35,3 +41,11 @@ shax9281930x892.s3-sa-east-1.amazonaws.com
 
 /paodequeijo/HGFGHGFH.php
 /sh2002039/000000.php
+/JarLOTESmefrasd121.php
+/KROmsoameo201920mda.php
+/LABrusoamdoo10192012.php
+/LOPRSMo109102912.php
+/ORTEGAHSK019mersoak.php
+/Posmeoirmso01929MKDK.php
+/timdim.php
+/timdim02.php


### PR DESCRIPTION
Have parsed addresses from screenshots (absent in IoC base list in the ESET's article).