### PR TITLE
latest DataPlane.org feeds added

### DIFF
--- a/trails/feeds/dataplane.py
+++ b/trails/feeds/dataplane.py
@@ -13,7 +13,7 @@ __reference__ = "dataplane.org"
 
 def fetch():
     retval = {}
-    for url in ("https://dataplane.org/dnsrd.txt", "https://dataplane.org/dnsrdany.txt", "https://dataplane.org/dnsversion.txt", "https://dataplane.org/sipinvitation.txt", "https://dataplane.org/sipquery.txt", "https://dataplane.org/sipregistration.txt", "https://dataplane.org/sshclient.txt", "https://dataplane.org/sshpwauth.txt", "https://dataplane.org/vncrfb.txt"):
+    for url in ("https://dataplane.org/dnsrd.txt", "https://dataplane.org/dnsrdany.txt", "https://dataplane.org/dnsversion.txt", "https://dataplane.org/proto41.txt", "https://dataplane.org/sipinvitation.txt", "https://dataplane.org/sipquery.txt", "https://dataplane.org/sipregistration.txt", "https://dataplane.org/smtpdata.txt", "https://dataplane.org/smtpgreet.txt", "https://dataplane.org/sshclient.txt", "https://dataplane.org/sshpwauth.txt", "https://dataplane.org/telnetlogin.txt", "https://dataplane.org/vncrfb.txt"):
         content = retrieve_content(url)
 
         if __check__ in content:


### PR DESCRIPTION
Hello,

There have been some new DataPlane.org feeds since the last pull request.  I've added them for your convenience.  It looks like the original independent feed parsers are no longer used as before.  All the feeds are the same format except proto41.txt has two time stamp fields, a "firstseen" and "lastseen".

John