### PR TITLE
Update apt_oceanlotus.txt

### DIFF
--- a/trails/static/malware/apt_oceanlotus.txt
+++ b/trails/static/malware/apt_oceanlotus.txt
@@ -639,3 +639,16 @@ widget.shoreoa.com
 # Reference: https://www.virustotal.com/gui/file/aa331051db461ff1dc760616f23770293a91257087fd079e2e76c122db7c0561/detection
 
 services.serveftp.net
+
+# Reference: https://twitter.com/360Netlab/status/1390297734981246978
+# Reference: https://blog.netlab.360.com/stealth_rotajakiro_backdoor_en/
+# Reference: https://blog.netlab.360.com/rotajakiro_linux_version_of_oceanlotus/
+
+eduelects.com
+mirror-codes.net
+thaprior.net
+sublineover.net
+blog.eduelects.com
+cdn.mirror-codes.net
+news.thaprior.net
+status.sublineover.net


### PR DESCRIPTION
Moving to trails from ```elf_rotajakiro.txt``` to ```apt_oceanlotus``` -- https://github.com/stamparm/maltrail/pull/16457 due to info: https://blog.netlab.360.com/rotajakiro_linux_version_of_oceanlotus/