### PR TITLE
Delete elf_rotajakiro.txt

### DIFF
--- a/trails/static/malware/elf_rotajakiro.txt
+++ b/trails/static/malware/elf_rotajakiro.txt
@@ -1,9 +1,0 @@
-# Copyright (c) 2014-2021 Maltrail developers (https://github.com/stamparm/maltrail/)
-# See the file 'LICENSE' for copying permission
-
-# Reference: https://blog.netlab.360.com/stealth_rotajakiro_backdoor_en/
-
-blog.eduelects.com
-cdn.mirror-codes.net
-news.thaprior.net
-status.sublineover.net


### PR DESCRIPTION
Moving to ```apt_oceanlotus```: https://github.com/stamparm/maltrail/pull/16456/commits/3f1817d44406632963ddc75dcb97a2e0ee903ff0 due to info: https://blog.netlab.360.com/rotajakiro_linux_version_of_oceanlotus/