### PR TITLE
Update kief.txt

### DIFF
--- a/trails/static/malware/kief.txt
+++ b/trails/static/malware/kief.txt
@@ -10,5 +10,7 @@ monster.casa
 
 # Generic
 
+/grabberstr
+/kiefgrabberstr
 /grabberstr?webhook=
 /kiefgrabberstr?webhook=


### PR DESCRIPTION
Minor patch for (potential) cases, if ```?webhook=``` is not the single variant here.