### PR TITLE
Update lodarat.txt

### DIFF
--- a/trails/static/malware/lodarat.txt
+++ b/trails/static/malware/lodarat.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014-2021 Maltrail developers (https://github.com/stamparm/maltrail/)
 # See the file 'LICENSE' for copying permission
 
-# Aliases: loda, lodalogger, lodarat
+# Aliases: 888rat, gaza007, loda, lodalogger, lodarat
 
 # Reference: https://twitter.com/James_inthe_box/status/1047193599660576768
 
@@ -146,3 +146,10 @@ info.v-pn.co
 # Reference: https://www.virustotal.com/gui/file/ad35057e3d652b30e43c1812c0147e5307ccf6aa92046eb2e00725d26d7664b1/detection
 
 78.189.177.240:4000
+
+# Reference: https://twitter.com/malwrhunterteam/status/1449375270910234628
+# Reference: https://twitter.com/LukasStefanko/status/1450007904413749248
+# Reference: https://www.virustotal.com/gui/file/7090c9075201589ca10073aa7292eceed05dc95d5fa792d7607aa73a6b94284b/detection
+
+193.161.193.99:50727
+888ratsetup-50727.portmap.host


### PR DESCRIPTION
```The newly discovered Android 888 RAT has been used by the Kasablanka group and by BladeHawk. Both of them used alternative names to refer to the same Android RAT – LodaRAT and Gaza007 respectively.``` <-- https://www.welivesecurity.com/2021/09/07/bladehawk-android-espionage-kurdish/