### PR TITLE
Add {buy, sell, sell2}.internettraffic.com in parking_site.txt

### DIFF
--- a/trails/static/suspicious/parking_site.txt
+++ b/trails/static/suspicious/parking_site.txt
@@ -4614,3 +4614,24 @@ bustbuy.com
 # SAV
 
 52.15.160.167
+
+# {buy, sell, sell2}.internettraffic.com
+# Reference: https://www.virustotal.com/gui/domain/buy.internettraffic.com/relations
+# Reference: https://www.virustotal.com/gui/domain/sell.internettraffic.com/relations
+# Reference: https://www.virustotal.com/gui/domain/sell2.internettraffic.com/relations
+# Reference: https://otx.alienvault.com/indicator/hostname/buy.internettraffic.com
+# Reference: https://otx.alienvault.com/indicator/hostname/sell.internettraffic.com
+# Reference: https://otx.alienvault.com/indicator/hostname/sell2.internettraffic.com
+# Reference: https://www.virustotal.com/gui/ip-address/54.152.30.238/relations
+# Reference: https://www.virustotal.com/gui/ip-address/52.128.23.153/relations
+# Reference: https://www.virustotal.com/gui/ip-address/52.89.18.51/relations
+# Reference: https://www.virustotal.com/gui/ip-address/34.247.146.68/relations
+# Reference: https://www.virustotal.com/gui/ip-address/18.217.16.210/relations
+# Reference: https://securitytrails.com/domain/buy.internettraffic.com/history/a
+# Reference: https://securitytrails.com/domain/sell2.internettraffic.com/history/a
+
+54.152.30.238
+52.128.23.153
+52.89.18.51
+34.247.146.68
+18.217.16.210

--- a/trails/static/suspicious/parking_site.txt
+++ b/trails/static/suspicious/parking_site.txt
@@ -4615,23 +4615,6 @@ bustbuy.com
 
 52.15.160.167
 
-# {buy, sell, sell2}.internettraffic.com
-# Reference: https://www.virustotal.com/gui/domain/buy.internettraffic.com/relations
-# Reference: https://www.virustotal.com/gui/domain/sell.internettraffic.com/relations
-# Reference: https://www.virustotal.com/gui/domain/sell2.internettraffic.com/relations
-# Reference: https://otx.alienvault.com/indicator/hostname/buy.internettraffic.com
-# Reference: https://otx.alienvault.com/indicator/hostname/sell.internettraffic.com
-# Reference: https://otx.alienvault.com/indicator/hostname/sell2.internettraffic.com
-# Reference: https://www.virustotal.com/gui/ip-address/54.152.30.238/relations
 # Reference: https://www.virustotal.com/gui/ip-address/52.128.23.153/relations
-# Reference: https://www.virustotal.com/gui/ip-address/52.89.18.51/relations
-# Reference: https://www.virustotal.com/gui/ip-address/34.247.146.68/relations
-# Reference: https://www.virustotal.com/gui/ip-address/18.217.16.210/relations
-# Reference: https://securitytrails.com/domain/buy.internettraffic.com/history/a
-# Reference: https://securitytrails.com/domain/sell2.internettraffic.com/history/a
 
-54.152.30.238
 52.128.23.153
-52.89.18.51
-34.247.146.68
-18.217.16.210


### PR DESCRIPTION
Found this when digging parking domain related issue like: #11332, maybe `worthingtonseniorliving.com` changed its parking service, looks like the new one was not recorded here.

![image](https://user-images.githubusercontent.com/3691490/160158418-65b50bf1-5efe-40ce-9a83-87cdb94be98c.png)
