### PR TITLE
Add `50.28.32.8` in parking_site.txt, 

### DIFF
--- a/trails/static/suspicious/parking_site.txt
+++ b/trails/static/suspicious/parking_site.txt
@@ -4636,3 +4636,7 @@ bustbuy.com
 # Reference: https://www.virustotal.com/gui/ip-address/46.8.8.100/relations
 
 46.8.8.100
+
+# Reference: https://www.virustotal.com/gui/ip-address/50.28.32.8/relations
+
+50.28.32.8


### PR DESCRIPTION
Parking IP of `wordbot.xyz`, `strainemergency.com`(in `misc/whitelist.txt`) and hundreds more.

Reference:
- https://otx.alienvault.com/indicator/ip/50.28.32.8
- https://www.virustotal.com/gui/ip-address/50.28.32.8/relations

cc #19058

