### PR TITLE
Remove fin7 false positives

### DIFF
--- a/trails/static/malware/fin7.txt
+++ b/trails/static/malware/fin7.txt
@@ -1053,24 +1053,8 @@ safarienzo.com
 # Reference: https://twitter.com/U039b/status/1387487404160860166
 # Reference: https://twitter.com/U039b/status/1387495127401308162
 # Reference: https://beta.pithus.org/report/ae05bbd31820c566543addbb0ddc7b19b05be3c098d0f7aa658ab83d6f6cd5c8
-# Reference: https://www.virustotal.com/gui/domain/qa-demo.wire.link/relations
 
 78.46.120.20:443
-account.qa-demo.wire.link
-assets.qa-demo.wire.link
-nginz-https.qa-demo.wire.link
-nginz-ssl.qa-demo.wire.link
-teams.qa-demo.wire.link
-webapp.qa-demo.wire.link
-account.wire.com
-clientblacklist.wire.com
-prod-nginz-https.wire.com
-prod-nginz-ssl.wire.com
-teams.wire.com
-staging-nginz-https.zinfra.io
-taging-nginz-ssl.zinfra.io
-wire-account-staging.zinfra.io
-wire-teams-staging.zinfra.io
 
 # Reference: https://twitter.com/kyleehmke/status/1396803284359319560
 


### PR DESCRIPTION
The removed domains are part of Wire's production infrastructure
(*.wire.com) and staging/testing infrastructure (*.zinfra.io /
*.wire.link)

The related fin7 sample was a modified Wire client.

This probably also resolves https://github.com/stamparm/aux/issues/5.