### PR TITLE
Remove Expo false positive

### DIFF
--- a/trails/static/suspicious/android_pua.txt
+++ b/trails/static/suspicious/android_pua.txt
@@ -314,10 +314,6 @@ applog.uc.cn
 
 uiltyfores.fun
 
-# Reference: https://www.virustotal.com/gui/domain/exp.host/relations
-
-exp.host
-
 # Reference: https://www.virustotal.com/gui/file/b0b90abff8a2eb5ba7c6d2c346fabc0f8f6a0034b6189a87f723e11fcd554511/detection
 
 162.243.164.124:8080


### PR DESCRIPTION
The removed domain is part of the core infrastructure for [Expo](https://expo.dev). (*.exp.host)

This is our main API endpoint and handles all API requests for developing Expo apps. We mostly use it in our [Expo SDK](https://github.com/expo/expo/blob/main/packages/expo-dev-launcher/bundle/apiClient.ts#L7-L13), and [Expo CLI](https://github.com/expo/expo-cli/blob/main/packages/xdl/src/Config.ts#L32). Including things like:
- Pulling the [Expo app manifest schema validation](https://docs.expo.dev/versions/v45.0.0/config/app/)
  https://exp.host/--/api/v2/project/configuration/schema/45.0.0
- Finding compatible versions of libraries per Expo SDK
  https://exp.host/--/api/v2/versions

I'm not sure why https://www.virustotal.com/gui/domain/exp.host/relations has a list of "Files Referring" that seem unrelated to what we host here. Some of the files are flagging 1 Trojan horse, but we can't find these files on our end. And the website doesn't show us the actual URL used to download those files.