### PR TITLE
Update whitelist.txt

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -227,6 +227,21 @@ tracker.lilithraws.cf
 rules2.clearurls.xyz
 torrents-csv.ml
 visitor-badge.laobi.icu
+free.publictracker.xyz
+run-2.publictracker.xyz
+run.publictracker.xyz
+tracker.publictracker.xyz
+public-tracker.ml
+tracker.imgoingto.icu
+searx.fmac.xyz
+eximage.cyou
+camhub.cc
+0xxx.ws
+lingva.ml
+insecam.org
+justdeleteme.xyz
+cyberpunk.xyz
+book.hacktricks.xyz
 
 # triggering potential DNS exhaustion
 


### PR DESCRIPTION
These are all false positives and being detected as suspicious but, not appearing in any of the trails, except `insecam.org`.

I have not found any up to date info on `insecam.org` i believe this may be a historic detection.

![Screenshot](https://user-images.githubusercontent.com/71215137/215736620-0775ccf1-08c8-45f7-998a-09db39b28050.png)
