### PR TITLE
Update android_roamingmantis.txt

### DIFF
--- a/trails/static/malware/android_roamingmantis.txt
+++ b/trails/static/malware/android_roamingmantis.txt
@@ -7586,6 +7586,7 @@ rvbbv.com
 rvbcv.com
 rwptm.com
 scqwt.com
+sdrsv.com
 spehq.com
 ssbyi.com
 sziby.com

--- a/trails/static/malware/android_roamingmantis.txt
+++ b/trails/static/malware/android_roamingmantis.txt
@@ -11212,6 +11212,10 @@ z-ms.zspwg.com
 
 z-7.nwesr.com
 
+# Reference: https://twitter.com/NaomiSuzuki_/status/1683326485405507585
+
+z-tc80.sdrsv.com
+
 # Reference: https://www.virustotal.com/gui/file/02449d4b0693559152b31f462334371abd684ba9660ec104a1305ccb41352cda/detection
 
 bincdi.6kvses.com


### PR DESCRIPTION
please take a look today's update. The domain name comes from a screenshot of the reference tweet, not tweet body.