### PR TITLE
one more

### DIFF
--- a/trails/static/malware/apt_pegasus.txt
+++ b/trails/static/malware/apt_pegasus.txt
@@ -1715,7 +1715,6 @@ download.fbr.tax
 
 123tramites.com
 adsmetrics.co
-cominfoquiz.net
 infoquiz.net
 nnews.co
 redirstats.com


### PR DESCRIPTION
the wrong entries came from the [paper](https://tspace.library.utoronto.ca/bitstream/1807/119418/1/Report_155--catalangate_012023_.pdf) 'statsupplier[.]cominfoquiz[.]net'