### PR TITLE
Remove improper aliases for teamspy

### DIFF
--- a/trails/static/malware/teamspy.txt
+++ b/trails/static/malware/teamspy.txt
@@ -1,8 +1,6 @@
 # Copyright (c) 2014-2023 Maltrail developers (https://github.com/stamparm/maltrail/)
 # See the file 'LICENSE' for copying permission
 
-# Aliases: phichichi, socks5systemz
-
 # Reference: https://kasperskycontenthub.com/wp-content/uploads/sites/43/vlpdfs/theteamspystory_final_t2.pdf
 
 politnews.org


### PR DESCRIPTION
Judging by the commit history, it seems like the aliases "phichichi" and "socks5systemz" were taken from this Tweet:
https://twitter.com/g0njxa/status/1701212547305607283
![image](https://github.com/stamparm/maltrail/assets/3027817/82a7ffa3-ab44-4c6f-905e-18b6924441a9)

However, the tweet seems to instead indicate that the given IP addresses are Socks5 Systemz systems that are being used by TeamSpy. It does not suggest that Socks5 Systemz is the same as TeamSpy.

Also, Pichichi/phichichi appears to be just the title on the displayed website, not the name of a malware family.

See also:
- https://malpedia.caad.fkie.fraunhofer.de/details/win.teamspy
- https://malpedia.caad.fkie.fraunhofer.de/details/win.socks5_systemz