### PR TITLE
Add aliases for apt_transparenttribe.txt

### DIFF
--- a/trails/static/malware/apt_transparenttribe.txt
+++ b/trails/static/malware/apt_transparenttribe.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014-2024 Maltrail developers (https://github.com/stamparm/maltrail/)
 # See the file 'LICENSE' for copying permission
 
-# Aliases: sidecopy, falseflag
+# Aliases: sidecopy, falseflag, apt36, mythic leopard
 
 # Reference: https://twitter.com/Timele9527/status/1144069969845481474
 # Reference: https://app.any.run/tasks/69351273-5fd3-4590-a5a5-da639f86f9ec/


### PR DESCRIPTION
Per:
https://blog.talosintelligence.com/transparent-tribe-infra-and-targeting/