### PR TITLE
Update whitelist.txt

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -4036,3 +4036,5 @@ slug.vercel.app
 2-can.njalla.in
 3-get.njalla.fo
 you.can-get-no.info
+
+45.12.1.25


### PR DESCRIPTION
For some reason this ip is being detected as a malware c2, it may have been in the past, but it is hosts torrentgalaxy.

Examples:
https://urlscan.io/ip/45.12.1.25
https://tgx.rs
https://torrentgalaxy.to
https://torrentgalaxy.mx
