### PR TITLE
fix: remove EOL DNSBL rbl.lugh.ch

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -825,7 +825,6 @@ rbl.efnetrbl.org
 rbl.fasthosts.co.uk
 rbl.interserver.net
 rbl.iprange.net
-rbl.lugh.ch
 rbl.megarbl.net
 rbl.orbitrbl.com
 rbl.polarcomm.net


### PR DESCRIPTION
The lugh RBL is EOL, this PR removes it from `misc/whitelist.txt`