### PR TITLE
Use host networking in docker

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,5 +12,5 @@
     for dev in $(ifconfig | grep mtu | grep -Eo '^\w+'); do ifconfig $dev promisc; done
     mkdir -p /var/log/maltrail/
     docker build -t maltrail . && \
-    docker run -d --name maltrail-docker --net=host --privileged -p 8337:8337/udp -p 8338:8338 -v /var/log/maltrail/:/var/log/maltrail/ -v $(pwd)/maltrail.conf:/opt/maltrail/maltrail.conf:ro maltrail
+    docker run -d --name maltrail-docker --net=host --privileged -v /var/log/maltrail/:/var/log/maltrail/ -v $(pwd)/maltrail.conf:/opt/maltrail/maltrail.conf:ro maltrail
 ```


### PR DESCRIPTION
From #19293; without host networking, the sensor can't access host interfaces from inside the docker container.  This is needed for the sensor, but not the server.  

When host networking is used, the port mappings, `-p`, must be removed or docker will fail.  Port mappings no longer mean anything because the container is using the host's networking stack.  See [docker docs: Host network driver](https://docs.docker.com/engine/network/drivers/host/). 