### PR TITLE
fix: Suppress python warnings in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3
 WORKDIR /opt/maltrail
-
+ENV PYTHONWARNINGS=ignore
 # Update OS
+
 RUN apt-get update && apt-get upgrade -y
 
 # Install dependencies


### PR DESCRIPTION
Fixes https://github.com/stamparm/maltrail/issues/19333 - at least suppresses the warnings. 