### PR TITLE
feat: Github Action for Docker build

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,38 @@
+name: Build and Push Docker Image on Tag
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract tag name
+        id: vars
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build Docker image
+        run: |
+          docker build -f docker/Dockerfile -t ghcr.io/${{ github.repository_owner }}/maltrail:${{ env.TAG }} .
+
+      - name: Push Docker image
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/maltrail:${{ env.TAG }}
+
+      - name: Optional: Also tag latest
+        run: |
+          docker tag ghcr.io/${{ github.repository_owner }}/maltrail:${{ env.TAG }} ghcr.io/${{ github.repository_owner }}/maltrail:latest
+          docker push ghcr.io/${{ github.repository_owner }}/maltrail:latest


### PR DESCRIPTION
This PR contains a small github actions script for building a new Docker image and pushing it to GHCR on a new git tag. For it to work you have to create a Token and set a secret  called GITHUB_TOKEN in this repository's settings with the token's value. Also, maybe you have to enable the container registry for this repo. 

Relates to https://github.com/stamparm/maltrail/issues/19325