### PR TITLE
Invalid IPv4 octets are accepted and can be silently corrupted

### DIFF
--- a/core/addr.py
+++ b/core/addr.py
@@ -11,7 +11,18 @@ from core.compat import xrange
 
 def addr_to_int(value):
     _ = value.split('.')
-    return (int(_[0]) << 24) + (int(_[1]) << 16) + (int(_[2]) << 8) + int(_[3])
+    if len(_) != 4:
+        raise ValueError("invalid IPv4 address '%s'" % value)
+
+    try:
+        _ = [int(__) for __ in _]
+    except ValueError:
+        raise ValueError("invalid IPv4 address '%s'" % value)
+
+    if any(__ < 0 or __ > 255 for __ in _):
+        raise ValueError("invalid IPv4 address '%s'" % value)
+
+    return (_[0] << 24) + (_[1] << 16) + (_[2] << 8) + _[3]
 
 def int_to_addr(value):
     return '.'.join(str(value >> n & 0xff) for n in (24, 16, 8, 0))


### PR DESCRIPTION
## Summary

`addr_to_int()` converts dot-separated parts with `int()` but never validates octet count/range. Inputs like `999.1.1.1` are accepted, and later conversions (e.g., via `int_to_addr`) can wrap values with `& 0xff`, producing a different IP than the original. This is silent data corruption in address handling and can lead to wrong trail matching/blocking behavior.

## Files changed

- `core/addr.py` (modified)

## Testing

- Not run in this environment.


Closes #19536