### PR TITLE
CIDR mask validation relies on `assert`, which is removed under optimized Python

### DIFF
--- a/core/addr.py
+++ b/core/addr.py
@@ -41,7 +41,8 @@ def expand_range(value):
     if match:
         prefix, mask = match.groups()
         mask = int(mask)
-        assert(mask <= 32)
+        if mask > 32:
+            return retval
 
         start_int = addr_to_int(prefix) & make_mask(mask)
         end_int = start_int | ((1 << 32 - mask) - 1)


### PR DESCRIPTION
## Summary

In `expand_range()`, `assert(mask <= 32)` is used as runtime validation. Under `python -O`, asserts are stripped, so malformed masks (e.g., `/64`) bypass validation and can trigger `ValueError: negative shift count` later (`1 << 32 - mask`). This becomes an unhandled runtime crash on malformed input.

## Files changed

- `core/addr.py` (modified)

## Testing

- Not run in this environment.


Closes #19538