### PR TITLE
Remove milktr.uk from vidar.txt

### DIFF
--- a/trails/static/malware/vidar.txt
+++ b/trails/static/malware/vidar.txt
@@ -792,7 +792,6 @@ http://188.34.200.103
 # Reference: https://github.com/ti-research-io/ti/blob/main/ioc_extender/TF_vidar.json
 
 derxblog.de
-milktr.uk
 
 # Reference: https://www.virustotal.com/gui/file/c3e725df442abe93e1d1d5ca01fc8105521c82e8e5f86d07171d8f95562c59a5/detection
 


### PR DESCRIPTION
Disclosure: I own and operate milktr.uk. It has been a landing page for a long time now. It has never hosted any malware.

tldr: milktr.uk is a false-positive

If I had to guess I think someone assumed it was part of a botnet. Several years ago I had hosted a Mastodon server for a friend. About a year into hosting it in 2021 we noticed strange accounts with nonsensical biographies being created over the span of two days. Turns out someone was using Mastodon account profile bios as a C2 for their [Vidar binaries they were sending to victims](https://threatfox.abuse.ch/browse.php?search=ioc%3Akoyu.space). We quickly purged all the accounts and it didn't happen again.

I hosted both, same IP, hence why someone seems to have (understandably) assumed it was doing something nefarious. The referenced link 404s but [this old copy](https://github.com/I85YL64/ti/blob/47cf56183217a4c084dfdb19e93eff7a91523170/ioc_extender/TF_vidar.json#L39-L50) seems to confirm what I guessed.  

This PR removes it. Hope that's ok.

More info:
