### PR TITLE
Fix false positive for Reddit onion domain (#19580)

### DIFF
--- a/misc/whitelist.txt
+++ b/misc/whitelist.txt
@@ -576,6 +576,9 @@ emlfiles4.com
 
 defensacentral.com
 
+# false positive (#19580)
+reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion
+
 # found as false positive on bambenekconsulting.com
 
 parkingcrew.net


### PR DESCRIPTION
Fixes #19580.

Added `reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion` to `misc/whitelist.txt` to prevent it from being flagged as rasprobin malware.