### PR TITLE
Remove false-positive blacklist entry for my domain

### DIFF
--- a/trails/static/malware/elf_mirai.txt
+++ b/trails/static/malware/elf_mirai.txt
@@ -58207,21 +58207,6 @@ http://93.123.109.160
 shinju-networks.net
 cnc.shinju-networks.net
 
-# Reference: https://x.com/redrabytes/status/1849337367863189820
-# CLASS_0_HASH-HOST=82f94b386bd4d7dc9f04a19553c244a9
-
-141.98.10.116:53648
-154.213.187.58:48920
-notcord.vip
-novo.geek
-novoline.pirate
-novoline.top
-nullify.wtf
-api.nullify.wtf
-s1.novo.geek
-s1.novoline.pirate
-s1.novoline.top
-pl-hex.rtc.notcord.vip
 
 # Reference: https://x.com/banthisguy9349/status/1849706028192969215
 


### PR DESCRIPTION
I host a small video chat app, and i noticed that my primary domain (along with one of its RTC server domains) is listed on your blacklist.

This appears to be a false positive: the domain is not present on any other blacklist like virustotal, and the referenced X post seems to have been removed. I don't know when and why it was added, as my project has been inactive for the past few months. I was planning to resume development, then I noticed that my dns blockers are blocking the domain.