### PR TITLE
Add IPWhois.net community blacklist feed

### DIFF
--- a/trails/feeds/ipwhois.py
+++ b/trails/feeds/ipwhois.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2014-2026 Maltrail developers (https://github.com/stamparm/maltrail/)
+See the file 'LICENSE' for copying permission
+"""
+
+from core.common import retrieve_content
+from core.settings import NAME
+
+__url__ = "https://bl.ipwhois.net/feed.txt"
+__check__ = "IPWhois.net Blacklist"
+__info__ = "known attacker"
+__reference__ = "ipwhois.net"
+
+def fetch():
+    retval = {}
+    content = retrieve_content(__url__, headers={"User-agent": NAME})
+
+    if __check__ in content:
+        for line in content.split('\n'):
+            line = line.strip()
+            if not line or line.startswith('#') or '.' not in line:
+                continue
+            retval[line] = (__info__, __reference__)
+
+    return retval


### PR DESCRIPTION
Adds a fetcher for the IPWhois.net community blacklist feed.

- Feed: https://bl.ipwhois.net/feed.txt (plain text, one IPv4 per line, `#` comments)
- Content: first-party reports only - IPs reported by users via the API, fail2ban/CSF integrations and our own honeypots. Third-party feeds that IPWhois.net mirrors on its website (blocklist.de, CI Army, IPsum, ...) are deliberately excluded from this file, so ingesting it does not create circular data.
- Criteria: confidence >= 50, seen within the last 90 days. Currently ~1,000 entries, regenerated every 30 minutes.
- Free to use, no key or signup. Docs: https://ipwhois.net/blacklist/docs

Fetcher follows the same pattern as greensnow.py. `__check__` matches the fixed header comment of the feed.

Disclosure: I run IPWhois.net.