### PR TITLE
remove uncle.finance false-positive Formbook trail

### DIFF
--- a/trails/static/malware/formbook.txt
+++ b/trails/static/malware/formbook.txt
@@ -7460,7 +7460,6 @@ strelingcollectibles.com
 theamalfiswim.com
 thedefinitionteam.store
 thrili.com
-uncle.finance
 undershieldz.com
 wicked-smokes.com
 wy-bride.com


### PR DESCRIPTION
uncle.finance appears in the Formbook static trail based on a malware sample from January 2022. The domain is now under unrelated ownership and is being used for a legitimate financial services product; the current site and infrastructure are unrelated to the historical malware sample.

Removing the stale domain IOC to prevent downstream false positives.