### PR TITLE
Remove captello.com false positives from apt_charmingkitten.txt

### DIFF
--- a/trails/static/malware/apt_charmingkitten.txt
+++ b/trails/static/malware/apt_charmingkitten.txt
@@ -2781,10 +2781,8 @@ calendar.fractionalleverage.com
 collab.vaf.ai
 crimson-peaks.com
 cstoddart-meeting-scheduler.firebaseapp.com
-demo-meeting.captello.com
 duschedule.ibridgellc.com
 eand.cyvehx.com
-eu-meeting.captello.com
 ez-calendar.vercel.app
 form.redberyl.co
 form.ritwiksingh.com
@@ -2812,7 +2810,6 @@ meeting-scheduler.tous33f.live
 meeting-scheduler.xyz
 meeting-scheduling.oldcountry.ai
 meeting-space-scheduler-9946.taskade.app
-meeting.captello.com
 meeting.dalqan.com
 meeting.ignsoftwares.in
 meeting.jackz.me
@@ -2847,7 +2844,6 @@ scheduler.scratchspace.dev
 scheduler.unionsavings.ca
 sirc.travyfy.com
 smart-sight-hr.com
-staging-meeting.captello.com
 tb-meet.pages.dev
 theush.uk
 threshold.tailba29da.ts.net


### PR DESCRIPTION
### Summary

Removes four `captello.com` subdomains from `trails/static/malware/apt_charmingkitten.txt`. They are production infrastructure of a legitimate SaaS vendor, not Charming Kitten / Nimbus Manticore infrastructure.

- `meeting.captello.com`
- `eu-meeting.captello.com`
- `demo-meeting.captello.com`
- `staging-meeting.captello.com`

### Why these are false positives

The enclosing block was added under these markers:

```
# Reference: https://www.nextron-systems.com/2026/06/01/detecting-nimbus-manticore-and-their-sideloading-infection-chains/
# FAVICON_HASH-HOST=c49bde355a787806ad5949a56c8730b0
# TITLE-HOST=Meeting Scheduler
```

That last line is the problem. The block was populated by matching hosts whose HTML page title is `Meeting Scheduler` — and **Captello sells a meeting scheduling product**, so its pages are titled exactly that:

```
$ curl -s https://meeting.captello.com/ | grep -o '<title>[^<]*</title>'
<title>Meeting Scheduler - Captello</title>

$ curl -s https://eu-meeting.captello.com/ | grep -o '<title>[^<]*</title>'
<title>Meeting Scheduler - Captello</title>
```

The title heuristic is doing what it was designed to do; it simply cannot distinguish threat-actor lures from the legitimate product category they are impersonating. Vendors in that category will keep getting swept in.

### Evidence that Captello is a legitimate company

**The company.** Captello is a Dallas, TX–based event marketing and lead capture software vendor, operating for 10+ years in the events space and 15+ years in sales/marketing SaaS. It is a named vendor with public press coverage, a LinkedIn company presence, agency partners, and enterprise customers.

- Company site: https://www.captello.com/
- Product page for the exact feature in question: https://www.captello.com/meeting-management
- Press coverage: [Dallas Innovates — "Dallas-Based Captello Launches Intelligent Scanner to 'Revolutionize' Event Data Capture"](https://dallasinnovates.com/dallas-based-captello-launches-intelligent-scanner-to-revolutionize-event-data-capture/)
- Product launch PR: [Captello Unveils Meeting Management Platform](https://www.prweb.com/releases/captello-unveils-meeting-management-platform-to-streamline-event-scheduling-and-maximize-roi-302401376.html)

**The product explains the hostname.** Captello publicly launched a Meeting Management Platform with 1:1 and group scheduling, approval workflows, smart matching, and calendar invites. `meeting.` is the product host and `eu-meeting.` is its EU region — a completely ordinary naming scheme for a SaaS vendor with EU data residency, not actor tradecraft.

**Infrastructure is consistent with a real business, not a disposable lure:**

| Signal | Value |
|---|---|
| `captello.com` registered | 2019-07-13 (~7 years, well past burner-domain lifespan) |
| Registrar | Amazon Registrar, Inc. |
| Hosting | AWS CloudFront (`108.159.102.0/24`, `3.175.196.0/24`) |
| TLS `meeting.captello.com` | `CN=meeting.captello.com`, Amazon RSA 2048 M01 |
| TLS `eu-meeting.captello.com` | `CN=eu-meeting.captello.com`, Amazon RSA 2048 M04 |

Long-lived corporate apex, stable AWS-hosted regional deployments, and per-host CA-issued certificates on the company's own domain — the opposite profile of throwaway phishing infrastructure.

**Why `demo-` and `staging-` are included.** They are the demo and staging environments of the same product on the same corporate apex, caught by the same title heuristic for the same reason. Removing only the production hosts would leave equally clean entries behind.

### Impact of leaving these in

Captello's customers are enterprise marketing and events teams. A blocklist hit on `meeting.captello.com` breaks meeting scheduling for those users mid-event and generates false incident escalations for the SOCs running Maltrail — noise that costs analyst time and erodes trust in the feed.

### Note

I have not touched any other entry in the block. The remaining hosts are left entirely as-is; this change is narrowly scoped to the four `captello.com` records.
