### PR TITLE
Add ThreatCluster feed

### DIFF
--- a/trails/feeds/threatcluster.py
+++ b/trails/feeds/threatcluster.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2014-2026 Maltrail developers (https://github.com/stamparm/maltrail/)
+See the file 'LICENSE' for copying permission
+"""
+
+from core.common import retrieve_content
+
+__url__ = "https://threatcluster.io/api/iocs/public/domains.txt#https://threatcluster.io/api/iocs/public/ips.txt"
+__check__ = "ThreatCluster public IOC feed"
+__info__ = "malicious"
+__reference__ = "threatcluster.io"
+
+def fetch():
+    retval = {}
+
+    for url in __url__.split('#'):
+        content = retrieve_content(url)
+
+        if __check__ in content:
+            for line in content.split('\n'):
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                retval[line] = (__info__, __reference__)
+
+    return retval


### PR DESCRIPTION
Adds the ThreatCluster public IOC feed (high-confidence malicious domains and IPs, validated, 30 day window, hourly refresh, no auth). Free direct downloads, details at https://threatcluster.io/iocs. Tested fetch() locally against the live endpoints.