### PR TITLE
Add feed for the BlueNoroff fake-meeting ClickFix kit

### DIFF
--- a/feeds/bluenoroff.py
+++ b/feeds/bluenoroff.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+"""
+Copyright (c) 2014-2026 Maltrail developers (https://github.com/stamparm/maltrail/)
+See the file 'LICENSE' for copying permission
+"""
+
+from core.common import retrieve_content
+
+__url__ = "https://raw.githubusercontent.com/farbodghasemlu/bluenoroff-fake-meeting-kit/main/iocs/indicators.csv"
+__check__ = "microteam"
+__info__ = "bluenoroff fake meeting kit"
+__reference__ = "github.com/farbodghasemlu/bluenoroff-fake-meeting-kit"
+
+def fetch():
+    retval = {}
+    content = retrieve_content(__url__)
+
+    if __check__ in content:
+        for line in content.split('\n'):
+            line = line.strip()
+            if not line or line.startswith('type,') or line.startswith('#'):
+                continue
+            parts = line.split(',')
+            if len(parts) < 2:
+                continue
+            kind, value = parts[0].strip(), parts[1].strip()
+            if kind not in ("domain", "ip"):
+                continue
+            if not value or '.' not in value:
+                continue
+            retval[value] = (__info__, __reference__)
+
+    return retval


### PR DESCRIPTION
# Add feed for the BlueNoroff fake-meeting ClickFix kit

Adds `feeds/bluenoroff.py`, a feed for the lure and C2 infrastructure of the
BlueNoroff (DPRK, a Lazarus subgroup) fake Zoom/Teams meeting ClickFix kit that
was active in August 2026.

## What it covers

The feed pulls a small, fixed set of attacker-controlled indicators: three lure
hosts (`us.zoom.web02z.us`, `us.zoom.02uweb.us`, `live.microteam.app`), their
registered domains, two backend/C2 hosts (`neowixbox.us`, `nohedcb.us`), the
sender-persona lookalike domain `walleye.fund`, and the associated IPs. All are
attacker-controlled. It labels them `bluenoroff fake meeting kit`.

Since this repository's static trails moved to a separate repository, this is
written as a feed module that fetches the list from the published research repo,
matching the other modules in `feeds/`.

## Prior work

Small addition to work already published by JUMPSEC ("Inside a DPRK BlueNoroff
ClickFix Kit", 2026-07-24) and Arctic Wolf (May 2026). Full analysis and
indicators: https://github.com/farbodghasemlu/bluenoroff-fake-meeting-kit

## Notes on precision

The bare registered domains and the lookalike domain are included because they
are attacker-registered, even though some no longer resolve. The kit's XAMPP
server banner (`Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12`) is deliberately
not used as an indicator, because on its own it matches more than 3,300
unrelated hosts. This feed lists only named attacker infrastructure.

## Validation

`ruff check --config ruff.toml feeds/bluenoroff.py` passes. The module exposes
`__url__`, `__info__`, `__reference__`, and `fetch()`, and its parser was run
against the published `indicators.csv` and returned the 15 expected trails.
